### PR TITLE
Implement custom outline for native workflows (.ga)

### DIFF
--- a/server/src/languageTypes.ts
+++ b/server/src/languageTypes.ts
@@ -45,6 +45,7 @@ import {
   DocumentFormattingParams,
   DocumentRangeFormattingParams,
   HoverParams,
+  DocumentSymbolParams,
 } from "vscode-languageserver/browser";
 import { WorkflowDocument } from "./models/workflowDocument";
 import {
@@ -110,6 +111,7 @@ export {
   DocumentFormattingParams,
   DocumentRangeFormattingParams,
   WorkflowDocument,
+  DocumentSymbolParams,
 };
 
 export interface FormattingOptions extends LSPFormattingOptions {

--- a/server/src/providers/symbolsProvider.ts
+++ b/server/src/providers/symbolsProvider.ts
@@ -1,0 +1,125 @@
+import { getRange } from "../languageService";
+import {
+  TextDocument,
+  DocumentSymbolParams,
+  DocumentSymbol,
+  SymbolKind,
+  ASTNode,
+  PropertyASTNode,
+} from "../languageTypes";
+import { GalaxyWorkflowLanguageServer } from "../server";
+import { Provider } from "./provider";
+
+export class SymbolsProvider extends Provider {
+  public static register(server: GalaxyWorkflowLanguageServer): SymbolsProvider {
+    return new SymbolsProvider(server);
+  }
+
+  constructor(server: GalaxyWorkflowLanguageServer) {
+    super(server);
+    this.connection.onDocumentSymbol((params) => this.onDocumentSymbol(params));
+  }
+
+  public onDocumentSymbol(params: DocumentSymbolParams): DocumentSymbol[] {
+    const workflowDocument = this.workflowDocuments.get(params.textDocument.uri);
+    if (workflowDocument) {
+      const symbols = this.getSymbols(workflowDocument.textDocument, workflowDocument.jsonDocument.root);
+      return symbols;
+    }
+    return [];
+  }
+
+  private getSymbols(document: TextDocument, root: ASTNode | undefined): DocumentSymbol[] {
+    if (!root) {
+      return [];
+    }
+    const result: DocumentSymbol[] = [];
+    const toVisit: { node: ASTNode; result: DocumentSymbol[] }[] = [{ node: root, result }];
+    let nextToVisit = 0;
+
+    const collectOutlineEntries = (node: ASTNode, result: DocumentSymbol[]) => {
+      if (node.type === "array") {
+        node.items.forEach((node, index) => {
+          if (node) {
+            const range = getRange(document, node);
+            const selectionRange = range;
+            const name = String(index);
+            const symbol = { name, kind: this.getSymbolKind(node.type), range, selectionRange, children: [] };
+            result.push(symbol);
+            toVisit.push({ result: symbol.children, node });
+          }
+        });
+      } else if (node.type === "object") {
+        node.properties.forEach((property: PropertyASTNode) => {
+          const valueNode = property.valueNode;
+          if (valueNode) {
+            const range = getRange(document, property);
+            const selectionRange = getRange(document, property.keyNode);
+            const children: DocumentSymbol[] = [];
+            const symbol: DocumentSymbol = {
+              name: this.getKeyLabel(property),
+              kind: this.getSymbolKind(valueNode.type),
+              range,
+              selectionRange,
+              children,
+              detail: this.getDetail(valueNode),
+            };
+            result.push(symbol);
+            toVisit.push({ result: children, node: valueNode });
+          }
+        });
+      }
+    };
+
+    while (nextToVisit < toVisit.length) {
+      const next = toVisit[nextToVisit++];
+      collectOutlineEntries(next.node, next.result);
+    }
+
+    return result;
+  }
+
+  private getSymbolKind(nodeType: string): SymbolKind {
+    switch (nodeType) {
+      case "object":
+        return SymbolKind.Module;
+      case "string":
+        return SymbolKind.String;
+      case "number":
+        return SymbolKind.Number;
+      case "array":
+        return SymbolKind.Array;
+      case "boolean":
+        return SymbolKind.Boolean;
+      default:
+        return SymbolKind.Variable;
+    }
+  }
+
+  private getKeyLabel(property: PropertyASTNode) {
+    let name = property.keyNode.value;
+    if (name) {
+      name = name.replace(/[\n]/g, "↵");
+    }
+    if (name && name.trim()) {
+      return name;
+    }
+    return `"${name}"`;
+  }
+
+  private getDetail(node: ASTNode | undefined) {
+    if (!node) {
+      return undefined;
+    }
+    if (node.type === "boolean" || node.type === "number" || node.type === "null" || node.type === "string") {
+      return String(node.value);
+    } else {
+      if (node.type === "array") {
+        return node.children.length ? undefined : "[]";
+      } else if (node.type === "object") {
+        return node.children.length ? undefined : "{}";
+      }
+    }
+    return undefined;
+  }
+}

--- a/server/src/providers/symbolsProvider.ts
+++ b/server/src/providers/symbolsProvider.ts
@@ -60,10 +60,13 @@ export class SymbolsProvider extends Provider {
           const valueNode = property.valueNode;
           if (valueNode) {
             let name = undefined;
+            let customSymbol = undefined;
             if (this.isStepProperty(property)) {
               name = this.getNodeName(property.valueNode);
+              customSymbol = "step";
             }
             name = name || this.getKeyLabel(property);
+            customSymbol = customSymbol || name;
             if (IGNORE_SYMBOL_NAMES.has(name)) {
               return;
             }
@@ -71,8 +74,8 @@ export class SymbolsProvider extends Provider {
             const selectionRange = getRange(document, property.keyNode);
             const children: DocumentSymbol[] = [];
             const symbol: DocumentSymbol = {
-              name: name || this.getKeyLabel(property),
-              kind: this.getSymbolKind(valueNode.type),
+              name: name,
+              kind: this.getSymbolKind(customSymbol),
               range,
               selectionRange,
               children,
@@ -105,12 +108,29 @@ export class SymbolsProvider extends Provider {
 
   private getSymbolKind(nodeType: string): SymbolKind {
     switch (nodeType) {
+      case "step":
+      case "subworkflow":
+        return SymbolKind.Function;
+      case "tool_id":
+        return SymbolKind.Property;
+      case "type":
+        return SymbolKind.TypeParameter;
+      case "class":
+        return SymbolKind.Class;
       case "object":
         return SymbolKind.Module;
       case "string":
         return SymbolKind.String;
+      case "annotation":
+      case "description":
+        return SymbolKind.Key;
+      case "id":
       case "number":
+      case "identifier":
         return SymbolKind.Number;
+      case "steps":
+      case "inputs":
+      case "outputs":
       case "array":
         return SymbolKind.Array;
       case "boolean":

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,6 +9,7 @@ import {
 import { CleanWorkflowCommand } from "./commands/cleanWorkflow";
 import { WorkflowLanguageService, TextDocument } from "./languageTypes";
 import { WorkflowDocuments } from "./models/workflowDocuments";
+import { SymbolsProvider } from "./providers/symbolsProvider";
 import { FormattingProvider } from "./providers/formattingProvider";
 import { HoverProvider } from "./providers/hoverProvider";
 
@@ -42,6 +43,7 @@ export class GalaxyWorkflowLanguageServer {
     const capabilities: ServerCapabilities = {
       documentFormattingProvider: true,
       hoverProvider: true,
+      documentSymbolProvider: true,
     };
 
     return {
@@ -52,6 +54,7 @@ export class GalaxyWorkflowLanguageServer {
   private registerProviders() {
     FormattingProvider.register(this);
     HoverProvider.register(this);
+    SymbolsProvider.register(this);
   }
 
   private registerCommands() {


### PR DESCRIPTION
This PR adds support for `DocumentSymbolProvider` to the native workflow language server by implementing a custom `SymbolsProvider` that displays only relevant information of the workflow and some other enhancements like displaying the actual name instead of the index for steps and other list elements.

![Outline](https://user-images.githubusercontent.com/46503462/154999557-b6f7dcad-5df1-4ff0-a184-e9ebf7946e93.gif)


Closes #4 