### PR TITLE
Add clean workflow command

### DIFF
--- a/client/src/commands/cleanWorkflow.ts
+++ b/client/src/commands/cleanWorkflow.ts
@@ -1,0 +1,28 @@
+import { window } from "vscode";
+import { CleanWorkflowDocumentParams, CleanWorkflowDocumentRequest } from "../requestsDefinitions";
+import { CustomCommand, getCommandFullIdentifier } from "./common";
+
+/**
+ * Command to 'clean' the selected workflow document.
+ * It will apply edits to remove the non-workflow logic related parts.
+ */
+export class CleanWorkflowCommand extends CustomCommand {
+  public static id = getCommandFullIdentifier("cleanWorkflow");
+  readonly identifier: string = CleanWorkflowCommand.id;
+
+  async execute(args: any[]): Promise<void> {
+    if (!window.activeTextEditor) {
+      return;
+    }
+    const { document } = window.activeTextEditor;
+
+    const params: CleanWorkflowDocumentParams = { uri: this.client.code2ProtocolConverter.asUri(document.uri) };
+    const result = await this.client.sendRequest(CleanWorkflowDocumentRequest.type, params);
+    if (!result) {
+      throw new Error("Cannot clean the requested document. The server returned no result.");
+    }
+    if (result.error) {
+      throw new Error(result.error);
+    }
+  }
+}

--- a/client/src/commands/setup.ts
+++ b/client/src/commands/setup.ts
@@ -5,6 +5,7 @@ import { SelectForCleanCompareCommand } from "./selectForCleanCompare";
 import { PreviewCleanWorkflowCommand } from "./previewCleanWorkflow";
 import { CleanWorkflowProvider } from "../providers/cleanWorkflowProvider";
 import { GitProvider } from "../providers/git/common";
+import { CleanWorkflowCommand } from "./cleanWorkflow";
 
 /**
  * Registers all custom commands declared in package.json
@@ -13,6 +14,7 @@ import { GitProvider } from "../providers/git/common";
  */
 export function setupCommands(context: ExtensionContext, client: CommonLanguageClient, gitProvider: GitProvider) {
   context.subscriptions.push(new PreviewCleanWorkflowCommand(client).register());
+  context.subscriptions.push(new CleanWorkflowCommand(client).register());
   const selectForCompareProvider = new SelectForCleanCompareCommand(client);
   context.subscriptions.push(selectForCompareProvider.register());
   context.subscriptions.push(

--- a/client/src/requestsDefinitions.ts
+++ b/client/src/requestsDefinitions.ts
@@ -3,7 +3,16 @@ import { RequestType } from "vscode-languageclient";
 // TODO: Move the contents of this file to a shared lib https://github.com/Microsoft/vscode/issues/15829
 
 export namespace LSRequestIdentifiers {
+  export const CLEAN_WORKFLOW_DOCUMENT = "galaxy-workflows-ls.cleanWorkflowDocument";
   export const CLEAN_WORKFLOW_CONTENTS = "galaxy-workflows-ls.cleanWorkflowContents";
+}
+
+export interface CleanWorkflowDocumentParams {
+  uri: string;
+}
+
+export interface CleanWorkflowDocumentResult {
+  error: string;
 }
 
 export interface CleanWorkflowContentsParams {
@@ -12,6 +21,12 @@ export interface CleanWorkflowContentsParams {
 
 export interface CleanWorkflowContentsResult {
   contents: string;
+}
+
+export namespace CleanWorkflowDocumentRequest {
+  export const type = new RequestType<CleanWorkflowDocumentParams, CleanWorkflowDocumentResult, void>(
+    LSRequestIdentifiers.CLEAN_WORKFLOW_DOCUMENT
+  );
 }
 
 export namespace CleanWorkflowContentsRequest {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,13 @@
 				"category": "Galaxy Workflows"
 			},
 			{
+				"command": "galaxy-workflows.cleanWorkflow",
+				"title": "Clean workflow",
+				"enablement": "resourceLangId == galaxyworkflow",
+				"icon": "$(edit)",
+				"category": "Galaxy Workflows"
+			},
+			{
 				"command": "galaxy-workflows.selectForCleanCompare",
 				"title": "Select workflow for (clean) compare",
 				"enablement": "resourceLangId == galaxyworkflow",
@@ -69,6 +76,10 @@
 			"commandPalette": [
 				{
 					"command": "galaxy-workflows.previewCleanWorkflow",
+					"when": "activeEditor"
+				},
+				{
+					"command": "galaxy-workflows.cleanWorkflow",
 					"when": "activeEditor"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -114,6 +114,12 @@
 					"group": "3_compare@2",
 					"when": "config.git.enabled && !git.missing && galaxy-workflows.gitProviderInitialized"
 				}
+			],
+			"editor/context": [
+				{
+					"command": "galaxy-workflows.cleanWorkflow",
+					"when": "resourceLangId == galaxyworkflow"
+				}
 			]
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -117,7 +117,13 @@
 			],
 			"editor/context": [
 				{
+					"command": "galaxy-workflows.previewCleanWorkflow",
+					"group": "galaxyworkflow@1",
+					"when": "resourceLangId == galaxyworkflow"
+				},
+				{
 					"command": "galaxy-workflows.cleanWorkflow",
+					"group": "galaxyworkflow@2",
 					"when": "resourceLangId == galaxyworkflow"
 				}
 			]

--- a/server/src/commands/requestsDefinitions.ts
+++ b/server/src/commands/requestsDefinitions.ts
@@ -3,7 +3,16 @@ import { RequestType } from "vscode-languageserver";
 // TODO: Move the contents of this file to a shared lib https://github.com/Microsoft/vscode/issues/15829
 
 export namespace LSRequestIdentifiers {
+  export const CLEAN_WORKFLOW_DOCUMENT = "galaxy-workflows-ls.cleanWorkflowDocument";
   export const CLEAN_WORKFLOW_CONTENTS = "galaxy-workflows-ls.cleanWorkflowContents";
+}
+
+export interface CleanWorkflowDocumentParams {
+  uri: string;
+}
+
+export interface CleanWorkflowDocumentResult {
+  error: string;
 }
 
 export interface CleanWorkflowContentsParams {
@@ -12,6 +21,12 @@ export interface CleanWorkflowContentsParams {
 
 export interface CleanWorkflowContentsResult {
   contents: string;
+}
+
+export namespace CleanWorkflowDocumentRequest {
+  export const type = new RequestType<CleanWorkflowDocumentParams, CleanWorkflowDocumentResult, void>(
+    LSRequestIdentifiers.CLEAN_WORKFLOW_DOCUMENT
+  );
 }
 
 export namespace CleanWorkflowContentsRequest {

--- a/server/src/models/workflowDocuments.ts
+++ b/server/src/models/workflowDocuments.ts
@@ -16,17 +16,17 @@ export class WorkflowDocuments {
   }
 
   public addOrReplaceWorkflowDocument(document: WorkflowDocument) {
-    console.log("registered workflow file: ", document.documentUri);
     this._documentsCache.set(document.documentUri, document);
+    //console.debug("workflow files registered: ", this._documentsCache.size);
   }
 
   public removeWorkflowDocument(documentUri: string) {
-    console.log("unregistered workflow file: ", documentUri);
     this._documentsCache.delete(documentUri);
+    //console.debug("workflow files registered: ", this._documentsCache.size);
   }
 
   public dispose() {
     this._documentsCache.clear();
-    console.log("workflow document cache cleared");
+    //console.debug("workflow document cache cleared");
   }
 }


### PR DESCRIPTION
Custom command to remove the non-essential properties of a workflow document.

Is similar to the `Preview clean workflow` command, but in this case, it actually **edits the current workflow document** instead of creating a preview.

The `Clean workflow` command can be accessed from the [command palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette) or in the active editor context menu when there is a valid workflow file in the current editor.

![clean-edit-workflow](https://user-images.githubusercontent.com/46503462/158027281-ea67e226-b5ba-42a3-8e8f-f32fe560da74.gif)


Closes #5