### PR TITLE
Add basic JSON schema validation

### DIFF
--- a/server/src/languageService.ts
+++ b/server/src/languageService.ts
@@ -76,7 +76,7 @@ export class NativeWorkflowLanguageService implements WorkflowLanguageService {
 
   private getWorkflowSchemaConfig(): SchemaConfiguration {
     return {
-      uri: this.schema.$id ?? "",
+      uri: this.schema.id ?? "",
       fileMatch: ["**.ga"],
       schema: this.schema,
     };

--- a/server/src/languageTypes.ts
+++ b/server/src/languageTypes.ts
@@ -121,6 +121,7 @@ export interface FormattingOptions extends LSPFormattingOptions {
 export interface WorkflowLanguageService {
   format(document: TextDocument, range: Range, options: FormattingOptions): TextEdit[];
   parseWorkflowDocument(document: TextDocument): WorkflowDocument;
+  doValidation(workflowDocument: WorkflowDocument): Promise<Diagnostic[]>;
 }
 
 export abstract class ServerContext {

--- a/server/src/models/workflowDocument.ts
+++ b/server/src/models/workflowDocument.ts
@@ -1,5 +1,5 @@
 import { JSONDocument } from "vscode-json-languageservice";
-import { TextDocument } from "../languageTypes";
+import { TextDocument, Range, Position, ASTNode } from "../languageTypes";
 
 /**
  * This class contains information about workflow semantics.
@@ -24,5 +24,27 @@ export class WorkflowDocument {
 
   public get jsonDocument(): JSONDocument {
     return this._jsonDocument;
+  }
+
+  public getNodeAtPosition(position: Position): ASTNode | undefined {
+    const offset = this.textDocument.offsetAt(position);
+    return this.jsonDocument.getNodeFromOffset(offset);
+  }
+
+  public getNodeRange(node: ASTNode): Range {
+    return Range.create(
+      this.textDocument.positionAt(node.offset),
+      this.textDocument.positionAt(node.offset + node.length)
+    );
+  }
+
+  public getNodeRangeAtPosition(position: Position): Range {
+    const node = this.getNodeAtPosition(position);
+    return node ? this.getNodeRange(node) : this.getDefaultRangeAtPosition(position);
+  }
+
+  private getDefaultRangeAtPosition(position: Position): Range {
+    const offset = this.textDocument.offsetAt(position);
+    return Range.create(this.textDocument.positionAt(offset), this.textDocument.positionAt(offset + 1));
   }
 }

--- a/server/src/providers/hoverProvider.ts
+++ b/server/src/providers/hoverProvider.ts
@@ -1,7 +1,6 @@
-import { Hover, HoverParams, MarkupKind, Position, ASTNode, WorkflowDocument, PropertyASTNode } from "../languageTypes";
+import { Hover, HoverParams, MarkupKind, ASTNode, PropertyASTNode } from "../languageTypes";
 import { GalaxyWorkflowLanguageServer } from "../server";
 import { Provider } from "./provider";
-import { getRange } from "../languageService";
 import { ArrayASTNode, BooleanASTNode, NullASTNode, NumberASTNode, StringASTNode } from "vscode-json-languageservice";
 
 export class HoverProvider extends Provider {
@@ -23,12 +22,12 @@ export class HoverProvider extends Provider {
     if (!workflowDocument) {
       return undefined;
     }
-    const node = this.getNodeAtDocumentPosition(workflowDocument, params.position);
+    const node = workflowDocument.getNodeAtPosition(params.position);
     if (!node) {
       return undefined;
     }
     const contentLines = this.printNode(node);
-    const hoverRange = getRange(workflowDocument.textDocument, node);
+    const hoverRange = workflowDocument.getNodeRange(node);
     const markdown = {
       kind: MarkupKind.Markdown,
       value: contentLines.join("\n\n"),
@@ -38,13 +37,6 @@ export class HoverProvider extends Provider {
       range: hoverRange,
     };
     return result;
-  }
-
-  private getNodeAtDocumentPosition(workflowDocument: WorkflowDocument, position: Position): ASTNode | undefined {
-    const document = workflowDocument.textDocument;
-    const offset = document.offsetAt(position);
-    const node = workflowDocument.jsonDocument.getNodeFromOffset(offset);
-    return node;
   }
 
   private printNode(node: ASTNode): string[] {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -74,14 +74,15 @@ export class GalaxyWorkflowLanguageServer {
     this.validate(workflowDocument);
   }
 
-  private onDidChangeContent(document: TextDocument) {
-    const workflowDocument = this.languageService.parseWorkflowDocument(document);
+  private onDidChangeContent(textDocument: TextDocument) {
+    const workflowDocument = this.languageService.parseWorkflowDocument(textDocument);
     this.workflowDocuments.addOrReplaceWorkflowDocument(workflowDocument);
     this.validate(workflowDocument);
   }
 
-  private onDidClose(document: TextDocument) {
-    this.workflowDocuments.removeWorkflowDocument(document.uri);
+  private onDidClose(textDocument: TextDocument) {
+    this.workflowDocuments.removeWorkflowDocument(textDocument.uri);
+    this.clearValidation(textDocument);
   }
 
   private cleanup() {
@@ -92,5 +93,9 @@ export class GalaxyWorkflowLanguageServer {
     this.languageService.doValidation(workflowDocument).then((diagnostics) => {
       this.connection.sendDiagnostics({ uri: workflowDocument.textDocument.uri, diagnostics });
     });
+  }
+
+  private clearValidation(textDocument: TextDocument) {
+    this.connection.sendDiagnostics({ uri: textDocument.uri, diagnostics: [] });
   }
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,7 +7,7 @@ import {
   WorkspaceFolder,
 } from "vscode-languageserver";
 import { CleanWorkflowCommand } from "./commands/cleanWorkflow";
-import { WorkflowLanguageService, TextDocument } from "./languageTypes";
+import { WorkflowLanguageService, TextDocument, WorkflowDocument } from "./languageTypes";
 import { WorkflowDocuments } from "./models/workflowDocuments";
 import { SymbolsProvider } from "./providers/symbolsProvider";
 import { FormattingProvider } from "./providers/formattingProvider";
@@ -68,14 +68,16 @@ export class GalaxyWorkflowLanguageServer {
     this.documents.onDidClose((event) => this.onDidClose(event.document));
   }
 
-  private onDocumentOpen(document: TextDocument) {
-    const workflowDocument = this.languageService.parseWorkflowDocument(document);
+  private onDocumentOpen(textDocument: TextDocument) {
+    const workflowDocument = this.languageService.parseWorkflowDocument(textDocument);
     this.workflowDocuments.addOrReplaceWorkflowDocument(workflowDocument);
+    this.validate(workflowDocument);
   }
 
   private onDidChangeContent(document: TextDocument) {
     const workflowDocument = this.languageService.parseWorkflowDocument(document);
     this.workflowDocuments.addOrReplaceWorkflowDocument(workflowDocument);
+    this.validate(workflowDocument);
   }
 
   private onDidClose(document: TextDocument) {
@@ -84,5 +86,11 @@ export class GalaxyWorkflowLanguageServer {
 
   private cleanup() {
     this.workflowDocuments.dispose();
+  }
+
+  private validate(workflowDocument: WorkflowDocument) {
+    this.languageService.doValidation(workflowDocument).then((diagnostics) => {
+      this.connection.sendDiagnostics({ uri: workflowDocument.textDocument.uri, diagnostics });
+    });
   }
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -7,6 +7,8 @@
         ],
         "module": "commonjs",
         "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "esModuleInterop": true,
         "sourceMap": true,
         "strict": true
     },

--- a/workflow-languages/schemas/native.schema.json
+++ b/workflow-languages/schemas/native.schema.json
@@ -4,7 +4,13 @@
     "type": "object",
     "properties": {
         "a_galaxy_workflow": {
-            "type": "string"
+            "type": "string",
+            "title": "## Galaxy Workflow indicator",
+            "markdownDescription": "Indicates that this JSON document is a **Galaxy Workflow**",
+            "default": "true",
+            "enum": [
+                "true"
+            ]
         },
         "annotation": {
             "type": "string"
@@ -47,7 +53,7 @@
         },
         "steps": {
             "type": "object",
-            "$ref": "#/definitions/stepDef"
+            "$ref": "#/definitions/step"
         },
         "tags": {
             "type": "array",
@@ -77,17 +83,18 @@
         "uuid"
     ],
     "definitions": {
-        "stepDef": {
+        "step": {
             "type": "object",
+            "additionalProperties": false,
             "patternProperties": {
-                "[0-9]*": {
+                "^[0-9]*$": {
                     "type": "object",
                     "properties": {
                         "annotation": {
                             "type": "string"
                         },
                         "content_id": {
-                            "type": "string"
+                            "$ref": "#/definitions/optionalString"
                         },
                         "errors": {
                             "type": "null"
@@ -119,7 +126,7 @@
                             ]
                         },
                         "label": {
-                            "type": "string"
+                            "$ref": "#/definitions/optionalString"
                         },
                         "name": {
                             "type": "string"
@@ -158,13 +165,13 @@
                             }
                         },
                         "tool_id": {
-                            "type": "null"
+                            "$ref": "#/definitions/optionalString"
                         },
                         "tool_state": {
                             "type": "string"
                         },
                         "tool_version": {
-                            "type": "null"
+                            "$ref": "#/definitions/optionalString"
                         },
                         "type": {
                             "type": "string"
@@ -179,7 +186,6 @@
                     },
                     "required": [
                         "annotation",
-                        "content_id",
                         "id",
                         "input_connections",
                         "inputs",
@@ -187,14 +193,18 @@
                         "outputs",
                         "position",
                         "tool_id",
-                        "tool_state",
-                        "tool_version",
                         "type",
                         "uuid",
                         "workflow_outputs"
                     ]
                 }
             }
+        },
+        "optionalString": {
+            "type": [
+                "string",
+                "null"
+            ]
         }
     }
 }

--- a/workflow-languages/schemas/native.schema.json
+++ b/workflow-languages/schemas/native.schema.json
@@ -1,4 +1,5 @@
 {
+    "id": "https://galaxyproject.org/schemas/workflow/native",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "properties": {

--- a/workflow-languages/schemas/native.schema.json
+++ b/workflow-languages/schemas/native.schema.json
@@ -1,0 +1,199 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "a_galaxy_workflow": {
+            "type": "string"
+        },
+        "annotation": {
+            "type": "string"
+        },
+        "creator": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "class": {
+                            "type": "string"
+                        },
+                        "identifier": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "class",
+                        "identifier",
+                        "name"
+                    ]
+                }
+            ]
+        },
+        "format-version": {
+            "type": "string"
+        },
+        "license": {
+            "type": "string"
+        },
+        "name": {
+            "type": "string"
+        },
+        "release": {
+            "type": "string"
+        },
+        "steps": {
+            "type": "object",
+            "$ref": "#/definitions/stepDef"
+        },
+        "tags": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "uuid": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "a_galaxy_workflow",
+        "annotation",
+        "creator",
+        "format-version",
+        "license",
+        "name",
+        "release",
+        "steps",
+        "tags",
+        "uuid"
+    ],
+    "definitions": {
+        "stepDef": {
+            "type": "object",
+            "patternProperties": {
+                "[0-9]*": {
+                    "type": "object",
+                    "properties": {
+                        "annotation": {
+                            "type": "string"
+                        },
+                        "content_id": {
+                            "type": "string"
+                        },
+                        "errors": {
+                            "type": "null"
+                        },
+                        "id": {
+                            "type": "integer"
+                        },
+                        "input_connections": {
+                            "type": "object"
+                        },
+                        "inputs": {
+                            "type": "array",
+                            "items": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "description": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "description",
+                                        "name"
+                                    ]
+                                }
+                            ]
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "outputs": {
+                            "type": "array",
+                            "items": {}
+                        },
+                        "position": {
+                            "type": "object",
+                            "properties": {
+                                "bottom": {
+                                    "type": "number"
+                                },
+                                "height": {
+                                    "type": "number"
+                                },
+                                "left": {
+                                    "type": "number"
+                                },
+                                "right": {
+                                    "type": "number"
+                                },
+                                "top": {
+                                    "type": "number"
+                                },
+                                "width": {
+                                    "type": "integer"
+                                },
+                                "x": {
+                                    "type": "number"
+                                },
+                                "y": {
+                                    "type": "number"
+                                }
+                            }
+                        },
+                        "tool_id": {
+                            "type": "null"
+                        },
+                        "tool_state": {
+                            "type": "string"
+                        },
+                        "tool_version": {
+                            "type": "null"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "uuid": {
+                            "type": "string"
+                        },
+                        "workflow_outputs": {
+                            "type": "array",
+                            "items": {}
+                        }
+                    },
+                    "required": [
+                        "annotation",
+                        "content_id",
+                        "id",
+                        "input_connections",
+                        "inputs",
+                        "name",
+                        "outputs",
+                        "position",
+                        "tool_id",
+                        "tool_state",
+                        "tool_version",
+                        "type",
+                        "uuid",
+                        "workflow_outputs"
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a basic schema validation for Galaxy *Native* Workflows (.ga)

![schemaValidation](https://user-images.githubusercontent.com/46503462/161441779-bfdbf5d3-4909-4e59-9ccb-c83e97849952.gif)

I couldn't find an existing JSON schema for *.ga* workflows, so a really basic, incomplete, and undocumented [JSON schema](https://json-schema.org/understanding-json-schema/index.html) has been added to the project [here](https://github.com/davelopez/galaxy-workflows-vscode/compare/explore_schema_validation?expand=1#diff-ca520ec29a6247008eaee82748a6a127d4a063cd14f95b2a6c14647fcc936c96). The extension will now validate all *.ga* files using this schema and should be easy to provide additional schema-based features like *hover documentation* and *autocompletion suggestions* in future PRs.

Extending and documenting the schema further should be also pretty easy by following the [documentation](https://json-schema.org/understanding-json-schema/index.html) any help with that will be much appreciated :)