### PR TITLE
Add schema-based auto-completion

### DIFF
--- a/server/src/languageService.ts
+++ b/server/src/languageService.ts
@@ -17,6 +17,7 @@ import {
   WorkflowLanguageService,
   Position,
   Hover,
+  CompletionList,
 } from "./languageTypes";
 import NativeWorkflowSchema from "../../workflow-languages/schemas/native.schema.json";
 
@@ -65,6 +66,15 @@ export class NativeWorkflowLanguageService implements WorkflowLanguageService {
       workflowDocument.jsonDocument
     );
     return hover;
+  }
+
+  public async doComplete(workflowDocument: WorkflowDocument, position: Position): Promise<CompletionList | null> {
+    const completionResult = await this._jsonLanguageService.doComplete(
+      workflowDocument.textDocument,
+      position,
+      workflowDocument.jsonDocument
+    );
+    return completionResult;
   }
 
   private getLanguageSettings(): LanguageSettings {

--- a/server/src/languageTypes.ts
+++ b/server/src/languageTypes.ts
@@ -132,6 +132,7 @@ export interface WorkflowLanguageService {
   parseWorkflowDocument(document: TextDocument): WorkflowDocument;
   doValidation(workflowDocument: WorkflowDocument): Promise<Diagnostic[]>;
   doHover(workflowDocument: WorkflowDocument, position: Position): Promise<Hover | null>;
+  doComplete(workflowDocument: WorkflowDocument, position: Position): Promise<CompletionList | null>;
 }
 
 export abstract class ServerContext {

--- a/server/src/providers/completionProvider.ts
+++ b/server/src/providers/completionProvider.ts
@@ -1,0 +1,22 @@
+import { CompletionList, CompletionParams } from "vscode-languageserver";
+import { GalaxyWorkflowLanguageServer } from "../server";
+import { Provider } from "./provider";
+
+export class CompletionProvider extends Provider {
+  public static register(server: GalaxyWorkflowLanguageServer): CompletionProvider {
+    return new CompletionProvider(server);
+  }
+
+  constructor(server: GalaxyWorkflowLanguageServer) {
+    super(server);
+    this.connection.onCompletion(async (params) => this.onCompletion(params));
+  }
+  private async onCompletion(params: CompletionParams): Promise<CompletionList | null> {
+    const workflowDocument = this.workflowDocuments.get(params.textDocument.uri);
+    if (workflowDocument) {
+      const result = await this.languageService.doComplete(workflowDocument, params.position);
+      return result;
+    }
+    return null;
+  }
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -13,6 +13,7 @@ import { SymbolsProvider } from "./providers/symbolsProvider";
 import { FormattingProvider } from "./providers/formattingProvider";
 import { HoverProvider } from "./providers/hover/hoverProvider";
 import { DebugHoverContentContributor } from "./providers/hover/debugHoverContentContributor";
+import { CompletionProvider } from "./providers/completionProvider";
 
 export class GalaxyWorkflowLanguageServer {
   public readonly languageService: WorkflowLanguageService;
@@ -44,6 +45,10 @@ export class GalaxyWorkflowLanguageServer {
     const capabilities: ServerCapabilities = {
       documentFormattingProvider: true,
       hoverProvider: true,
+      completionProvider: {
+        resolveProvider: false,
+        triggerCharacters: ['"', ":"],
+      },
       documentSymbolProvider: true,
     };
 
@@ -58,6 +63,7 @@ export class GalaxyWorkflowLanguageServer {
       // new DebugHoverContentContributor(), //TODO remove this contributor before release
     ]);
     SymbolsProvider.register(this);
+    CompletionProvider.register(this);
   }
 
   private registerCommands() {

--- a/workflow-languages/schemas/native.schema.json
+++ b/workflow-languages/schemas/native.schema.json
@@ -12,62 +12,32 @@
                 "true"
             ]
         },
+        "name": {
+            "type": "string"
+        },
         "annotation": {
             "type": "string"
         },
         "creator": {
-            "type": "array",
-            "items": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "class": {
-                            "type": "string"
-                        },
-                        "identifier": {
-                            "type": "string"
-                        },
-                        "name": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "class",
-                        "identifier",
-                        "name"
-                    ]
-                }
-            ]
-        },
-        "format-version": {
-            "type": "string"
+            "$ref": "#/definitions/creator"
         },
         "license": {
             "type": "string"
         },
-        "name": {
+        "format-version": {
             "type": "string"
         },
         "release": {
             "type": "string"
         },
-        "steps": {
-            "type": "object",
-            "$ref": "#/definitions/step"
-        },
         "tags": {
-            "type": "array",
-            "items": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "string"
-                }
-            ]
+            "$ref": "#/definitions/tags"
         },
         "uuid": {
             "type": "string"
+        },
+        "steps": {
+            "$ref": "#/definitions/steps"
         }
     },
     "required": [
@@ -83,9 +53,53 @@
         "uuid"
     ],
     "definitions": {
-        "step": {
+        "creator": {
+            "type": "array",
+            "items": [
+                {
+                    "$ref": "#/definitions/contributor"
+                }
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "properties": {
+                "class": {
+                    "type": "string",
+                    "default": "Person",
+                    "enum": [
+                        "Person"
+                    ]
+                },
+                "identifier": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "class",
+                "identifier",
+                "name"
+            ]
+        },
+        "tags": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "steps": {
             "type": "object",
             "additionalProperties": false,
+            "patternProperties": {
+                "^[0-9]*$": {
+                    "$ref": "#/definitions/step"
+                }
+            },
             "defaultSnippets": [
                 {
                     "label": "Workflow Step",
@@ -101,118 +115,131 @@
                         }
                     }
                 }
-            ],
-            "patternProperties": {
-                "^[0-9]*$": {
-                    "type": "object",
-                    "properties": {
-                        "annotation": {
-                            "type": "string"
-                        },
-                        "content_id": {
-                            "$ref": "#/definitions/optionalString"
-                        },
-                        "errors": {
-                            "type": "null"
-                        },
-                        "id": {
-                            "type": "integer"
-                        },
-                        "input_connections": {
-                            "type": "object"
-                        },
-                        "inputs": {
-                            "type": "array",
-                            "items": [
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "description": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "description",
-                                        "name"
-                                    ]
-                                }
-                            ]
-                        },
-                        "label": {
-                            "$ref": "#/definitions/optionalString"
-                        },
-                        "name": {
-                            "type": "string"
-                        },
-                        "outputs": {
-                            "type": "array",
-                            "items": {}
-                        },
-                        "position": {
-                            "type": "object",
-                            "properties": {
-                                "bottom": {
-                                    "type": "number"
-                                },
-                                "height": {
-                                    "type": "number"
-                                },
-                                "left": {
-                                    "type": "number"
-                                },
-                                "right": {
-                                    "type": "number"
-                                },
-                                "top": {
-                                    "type": "number"
-                                },
-                                "width": {
-                                    "type": "integer"
-                                },
-                                "x": {
-                                    "type": "number"
-                                },
-                                "y": {
-                                    "type": "number"
-                                }
-                            }
-                        },
-                        "tool_id": {
-                            "$ref": "#/definitions/optionalString"
-                        },
-                        "tool_state": {
-                            "type": "string"
-                        },
-                        "tool_version": {
-                            "$ref": "#/definitions/optionalString"
-                        },
-                        "type": {
-                            "type": "string"
-                        },
-                        "uuid": {
-                            "type": "string"
-                        },
-                        "workflow_outputs": {
-                            "type": "array",
-                            "items": {}
-                        }
-                    },
-                    "required": [
-                        "annotation",
-                        "id",
-                        "input_connections",
-                        "inputs",
-                        "name",
-                        "outputs",
-                        "position",
-                        "tool_id",
-                        "type",
-                        "uuid",
-                        "workflow_outputs"
-                    ]
+            ]
+        },
+        "step": {
+            "type": "object",
+            "properties": {
+                "annotation": {
+                    "type": "string"
+                },
+                "content_id": {
+                    "$ref": "#/definitions/optionalString"
+                },
+                "errors": {
+                    "type": "null"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "input_connections": {
+                    "type": "object"
+                },
+                "inputs": {
+                    "$ref": "#/definitions/inputs"
+                },
+                "outputs": {
+                    "$ref": "#/definitions/outputs"
+                },
+                "label": {
+                    "$ref": "#/definitions/optionalString"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "position": {
+                    "$ref": "#/definitions/position"
+                },
+                "tool_id": {
+                    "$ref": "#/definitions/optionalString"
+                },
+                "tool_state": {
+                    "type": "string"
+                },
+                "tool_version": {
+                    "$ref": "#/definitions/optionalString"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "uuid": {
+                    "type": "string"
+                },
+                "workflow_outputs": {
+                    "$ref": "#/definitions/workflowOutputs"
+                }
+            },
+            "required": [
+                "annotation",
+                "id",
+                "input_connections",
+                "inputs",
+                "name",
+                "outputs",
+                "position",
+                "tool_id",
+                "type",
+                "uuid",
+                "workflow_outputs"
+            ]
+        },
+        "inputs": {
+            "type": "array",
+            "items": [
+                {
+                    "$ref": "#/definitions/input"
+                }
+            ]
+        },
+        "input": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "description",
+                "name"
+            ]
+        },
+        "outputs": {
+            "type": "array",
+            "items": {}
+        },
+        "workflowOutputs": {
+            "type": "array",
+            "items": {}
+        },
+        "position": {
+            "type": "object",
+            "properties": {
+                "bottom": {
+                    "type": "number"
+                },
+                "height": {
+                    "type": "number"
+                },
+                "left": {
+                    "type": "number"
+                },
+                "right": {
+                    "type": "number"
+                },
+                "top": {
+                    "type": "number"
+                },
+                "width": {
+                    "type": "integer"
+                },
+                "x": {
+                    "type": "number"
+                },
+                "y": {
+                    "type": "number"
                 }
             }
         },

--- a/workflow-languages/schemas/native.schema.json
+++ b/workflow-languages/schemas/native.schema.json
@@ -86,6 +86,22 @@
         "step": {
             "type": "object",
             "additionalProperties": false,
+            "defaultSnippets": [
+                {
+                    "label": "Workflow Step",
+                    "description": "Defines a workflow step with basic properties",
+                    "body": {
+                        "${1:0}": {
+                            "id": "^$1",
+                            "name": "$2",
+                            "label": "$3",
+                            "annotation": "$4",
+                            "inputs": [],
+                            "outputs": []
+                        }
+                    }
+                }
+            ],
             "patternProperties": {
                 "^[0-9]*$": {
                     "type": "object",


### PR DESCRIPTION
A simple wrapper around the JSON language service `doComplete` function to provide completion suggestions based on the .ga schema definitions.

![completion](https://user-images.githubusercontent.com/46503462/163582695-54eeaeba-da4c-4f3d-8ad2-a459a19a090e.gif)


Also, the schema has been refactored to move the complex objects to their own definitions.