### PR TITLE
Add compound launch configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,9 +34,9 @@
       }
     },
     {
+      "name": "Attach to Server",
       "type": "node",
       "request": "attach",
-      "name": "Attach to Server",
       "port": 6009,
       "restart": true,
       "sourceMapPathOverrides": {
@@ -70,6 +70,18 @@
         "type": "npm",
         "script": "test-compile"
       }
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Debug Extension + Server",
+      "configurations": ["Launch Extension", "Attach to Server"],
+      "presentation": {
+        "hidden": false,
+        "group": "",
+        "order": 1
+      },
+      "stopAll": true
     }
   ]
 }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -64,9 +64,9 @@ If you have installed the recommended extensions in [extensions.json](../.vscode
 
 ### Launch/Debug the extension locally
 
-Run the `Launch Extension` configuration from the `Run and Debug` action bar (or press F5).
+Run the `Debug Extension + Server` configuration from the `Run and Debug` action bar (or press F5).
 
-If you want to debug the _Workflow Language Server_, select and run the `Attach to Server` configuration when the extension is already running.
+This will launch the extension in a new VSCode instance and also attach the debugger to the _Workflow Language Server_ so you can add breakpoints and debug both `client` and `server` projects.
 
 ### Test the extension on [vscode.dev](https://vscode.dev/)
 


### PR DESCRIPTION
This makes it easier to debug both, the `extension` and the `workflow language server` without needing to manually attach the debugger to the server once the extension is loaded.

Simply run the `Debug Extension + Server` configuration from the `Run and Debug` action bar (or press F5).