### PR TITLE
Fix extension debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,13 +16,14 @@
         "type": "npm",
         "script": "watch"
       },
+      "resolveSourceMapLocations": ["${workspaceFolder}/client/dist/**/*.js"],
       "sourceMapPathOverrides": {
         "webpack://?:*/*": "${workspaceFolder}/client/*"
       }
     },
     {
       "name": "Launch Extension in Webworker",
-      "type": "pwa-extensionHost",
+      "type": "extensionHost",
       "debugWebWorkerHost": true,
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionDevelopmentKind=web"],
@@ -38,6 +39,9 @@
       "type": "node",
       "request": "attach",
       "port": 6009,
+      "sourceMaps": true,
+      "smartStep": true,
+      "resolveSourceMapLocations": ["${workspaceFolder}/server/gx-workflow-ls-native/dist/**/*.js"],
       "sourceMapPathOverrides": {
         "webpack://?:*/*": "${workspaceFolder}/server/gx-workflow-ls-native/*"
       }
@@ -47,6 +51,9 @@
       "type": "node",
       "request": "attach",
       "port": 6010,
+      "sourceMaps": true,
+      "smartStep": true,
+      "resolveSourceMapLocations": ["${workspaceFolder}/server/gx-workflow-ls-format2/dist/**/*.js"],
       "sourceMapPathOverrides": {
         "webpack://?:*/*": "${workspaceFolder}/server/gx-workflow-ls-format2/*"
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,5 @@
       "@schemas/*": ["./workflow-languages/schemas/*"]
     }
   },
-  "files": [],
-  "include": [],
   "exclude": []
 }


### PR DESCRIPTION
Fixes breakpoints not being properly bound when launching the extension in debug mode because the source maps were not resolved correctly after some of the dependencies updates.