### PR TITLE
Disable clean diff comparisons in Timeline (temporarily)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,10 @@ You can clean up the non-essential properties of a (legacy .ga) workflow with th
 
 > ⚠️ This feature is experimental and is only available using a local git repository.
 
-Sometimes you want to compare different revisions of the same (legacy .ga) workflow and see what has changed between them. If the workflow has been through the Galaxy editor or some of the nodes have been moved around, there can be many changes that are just cosmetical and not part of the workflow logic. In those cases, you may want to get a 'simplified' diff so you can focus on the 'real' changes. You can do so in the `Timeline` or the `File Explorer` by using `Select workflow for (clean) compare` in one revision and then `Compare with this workflow (clean)` on the other revision, this will compare both revisions using the 'clean' version of the workflow (see the [Workflow Cleanup Command](#workflow-cleanup-command)), meaning the non-essential parts are removed from both documents before the comparison.
+Sometimes you want to compare different revisions of the same (legacy .ga) workflow and see what has changed between them. If the workflow has been through the Galaxy editor or some of the nodes have been moved around, there can be many changes that are just cosmetical and not part of the workflow logic. In those cases, you may want to get a 'simplified' diff so you can focus on the 'real' changes. You can do so in <del>the `Timeline` or</del> the `File Explorer` by using `Select workflow for (clean) compare` in one revision and then `Compare with this workflow (clean)` on the other revision, this will compare both revisions using the 'clean' version of the workflow (see the [Workflow Cleanup Command](#workflow-cleanup-command)), meaning the non-essential parts are removed from both documents before the comparison.
+
+> ⚠️ **NOTE**:
+> This feature is no longer supported in the `Timeline` until a new version of the VSCode Timeline API is finalized and published. See [this PR](https://github.com/davelopez/galaxy-workflows-vscode/pull/59) for more details.
 
 #### Legacy (ga)
 

--- a/client/src/commands/compareCleanWith.ts
+++ b/client/src/commands/compareCleanWith.ts
@@ -26,7 +26,7 @@ export class CompareCleanWithWorkflowsCommand extends CustomCommand {
     const rightComparable = ComparableWorkflow.buildFromArgs(args);
 
     if (!leftComparable || !rightComparable) {
-      throw new Error("You need to two workflows selected for comparison");
+      throw new Error("You need to have two workflows selected for comparison");
     }
 
     const leftUri = this.buildCleanWorkflowUri(leftComparable);

--- a/client/src/commands/index.ts
+++ b/client/src/commands/index.ts
@@ -55,16 +55,21 @@ export abstract class CustomCommand extends CommandContext {
  */
 export class ComparableWorkflow {
   uri: Uri;
-  ref: string;
+  ref?: string;
 
+  // TODO: This is no longer working until a new API is available
+  // ref: https://github.com/microsoft/vscode/issues/177319
+  // ref: https://github.com/microsoft/vscode/issues/84297
   public static buildFromArgs(args: unknown[]): ComparableWorkflow | undefined {
     if (args.length >= 2) {
-      if (Object.prototype.hasOwnProperty.call(args[0], "ref")) {
+      const source = args[2] as string;
+      if (source === "git-history") {
         // Comes from source control timeline
-        return { uri: args[1] as Uri, ref: args[0]["ref"] };
-      } else if (Object.prototype.hasOwnProperty.call(args[0], "scheme")) {
-        // Comes from file explorer
-        return { uri: args[0] as Uri, ref: undefined };
+        return { uri: args[1] as Uri, ref: args[0] as string };
+      }
+      if (source === "timeline.localHistory") {
+        // Comes from local history
+        return { uri: args[1] as Uri };
       }
     }
     return undefined;

--- a/package.json
+++ b/package.json
@@ -168,12 +168,12 @@
         {
           "command": "galaxy-workflows.compareCleanWith",
           "group": "3_compare@1",
-          "when": "config.git.enabled && !git.missing && galaxy-workflows.selectForCleanCompare"
+          "when": "false && config.git.enabled && !git.missing && galaxy-workflows.selectForCleanCompare"
         },
         {
           "command": "galaxy-workflows.selectForCleanCompare",
           "group": "3_compare@2",
-          "when": "config.git.enabled && !git.missing && timelineItem =~ /git:file\\b/ && galaxy-workflows.gitProviderInitialized"
+          "when": "false && config.git.enabled && !git.missing && timelineItem =~ /git:file\\b/ && galaxy-workflows.gitProviderInitialized"
         }
       ],
       "explorer/context": [


### PR DESCRIPTION
xref #56

This disables the options to compare (clean versions) of workflows using the Timeline.

![image](https://github.com/davelopez/galaxy-workflows-vscode/assets/46503462/6644adf6-7c4e-46a4-9126-ad2503258541)


In recent versions of VSCode, the [Timeline does not provide useful information for its items anymore](https://github.com/microsoft/vscode/issues/177319), so we need to wait until the [VSCode Timeline API](https://github.com/microsoft/vscode/issues/84297) is finalized and published.

A possible alternative will be to support the current [Timeline "proposed" API](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.timeline.d.ts) but this will only work on [VSCode Insiders](https://code.visualstudio.com/insiders/) in combination with a preview version of the extension (that cannot be published) and the API can change and break during the process.