### PR TITLE
Match only YAML files with `gxwf.yml` suffix

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,10 +61,8 @@
           "Galaxy Workflow (YAML)"
         ],
         "extensions": [
-          ".yml",
           ".gxwf.yml"
         ],
-        "firstLine": "^class: GalaxyWorkflow",
         "configuration": "./workflow-languages/configurations/yml.language-configuration.json"
       }
     ],


### PR DESCRIPTION
The `firstLine` regex doesn't seem to discriminate any other kind of YAML file, so for the sake of getting fewer false positives (that can be potentially annoying), let's limit the extension activation matching to workflow files that have the suffix `gxwf.yml`.

### In other words, **only workflow files with the extension `.gxwf.yml` will be considered Galaxy Workflows** in VSCode.