### PR TITLE
Fix step export error validation rule

### DIFF
--- a/server/gx-workflow-ls-format2/tests/integration/validation.test.ts
+++ b/server/gx-workflow-ls-format2/tests/integration/validation.test.ts
@@ -1,4 +1,5 @@
 import { Diagnostic, ValidationRule } from "@gxwf/server-common/src/languageTypes";
+import { StepExportErrorValidationRule } from "@gxwf/server-common/src/providers/validation/rules";
 import { GalaxyWorkflowFormat2SchemaLoader } from "../../src/schema";
 import { GxFormat2SchemaValidationService } from "../../src/services/schemaValidationService";
 import { InputTypeValidationRule } from "../../src/validation/rules/InputTypeValidationRule";
@@ -118,6 +119,50 @@ inputs:
         default: 42
 outputs:
 steps:
+    `;
+        const diagnostics = await validateRule(content);
+        expect(diagnostics).toHaveLength(0);
+      });
+    });
+
+    describe("StepExportErrorValidationRule", () => {
+      beforeAll(() => {
+        rule = new StepExportErrorValidationRule();
+      });
+
+      it("should report error when step contains export errors", async () => {
+        const content = `
+class: GalaxyWorkflow
+steps:
+    step:
+        tool_id: tool_id
+        errors: error in step
+    `;
+        const diagnostics = await validateRule(content);
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0].message).toContain(
+          "Tool step contains error indicated during Galaxy export - error in step"
+        );
+      });
+
+      it("should not report error when step does not contain export errors", async () => {
+        const content = `
+class: GalaxyWorkflow
+steps:
+    step:
+        tool_id: tool_id
+    `;
+        const diagnostics = await validateRule(content);
+        expect(diagnostics).toHaveLength(0);
+      });
+
+      it("should not report error when step errors are null", async () => {
+        const content = `
+class: GalaxyWorkflow
+steps:
+    step:
+        tool_id: tool_id
+        errors: null
     `;
         const diagnostics = await validateRule(content);
         expect(diagnostics).toHaveLength(0);

--- a/server/packages/server-common/src/providers/validation/rules/StepErrorValidationRule.ts
+++ b/server/packages/server-common/src/providers/validation/rules/StepErrorValidationRule.ts
@@ -10,19 +10,21 @@ export class StepExportErrorValidationRule implements ValidationRule {
   public async validate(documentContext: DocumentContext): Promise<Diagnostic[]> {
     const diagnostics: Diagnostic[] = [];
     const steps = documentContext.nodeManager.getStepNodes(true);
-    steps.forEach((step) => {
+    for (const step of steps) {
       const errors = step.properties.find((p) => p.keyNode.value === "errors");
-      if (errors) {
+      if (errors && errors.valueNode && errors.valueNode.type !== "null") {
         const range = documentContext.nodeManager.getNodeRange(errors);
+        const valueRange = documentContext.nodeManager.getNodeRange(errors.valueNode);
+        const errorValue = documentContext.textDocument.getText(valueRange);
         diagnostics.push(
           Diagnostic.create(
             range,
-            `Tool step contains error indicated during Galaxy export - ${errors}`,
-            DiagnosticSeverity.Warning
+            `Tool step contains error indicated during Galaxy export - ${errorValue}`,
+            this.severity
           )
         );
       }
-    });
+    }
     return Promise.resolve(diagnostics);
   }
 }


### PR DESCRIPTION
- Do not report null values
- Include the correct error value in the diagnostic message
- Use given severity instead of hardcoded warning