### PR TITLE
Fix duplicated document cache on remote GitHub repositories

### DIFF
--- a/server/packages/server-common/src/models/documentsCache.ts
+++ b/server/packages/server-common/src/models/documentsCache.ts
@@ -9,7 +9,7 @@ export class DocumentsCacheImpl implements DocumentsCache {
    * Document URI schemes that represent temporal or readonly documents
    * that should not be cached.
    */
-  private static schemesToSkip = ["temp", "galaxy-clean-workflow"];
+  private static schemesToSkip = ["temp", "galaxy-clean-workflow", "github"];
 
   constructor() {
     this.cache = new Map<string, DocumentContext>();


### PR DESCRIPTION
When opening a file in `GitHub.dev`, two virtual documents, with the same contents but different URI schemes, are sent to the language server one with `vscode-vfs` scheme (editable) and one with `github` scheme (read-only).

Processing both by the server will result in duplicated diagnostics, so we skip the read-only one.