### PR TITLE
Fix Format2 compatible primitive types validation

### DIFF
--- a/server/gx-workflow-ls-format2/src/schema/definitions.ts
+++ b/server/gx-workflow-ls-format2/src/schema/definitions.ts
@@ -1,3 +1,5 @@
+import { isCompatibleType, isWorkflowDataType } from "@gxwf/server-common/src/utils";
+
 export interface SchemaDocument {
   $base: string;
   $namespaces?: object;
@@ -266,7 +268,10 @@ export class FieldSchemaNode implements SchemaNode, IdMapper {
     if (this.canBeAny) return true;
     if (typeName === "null" && this.isOptional) return true;
     for (const allowedType of this._allowedTypes) {
-      if (allowedType.typeName === typeName) {
+      if (
+        allowedType.typeName === typeName ||
+        (isWorkflowDataType(allowedType.typeName) && isCompatibleType(allowedType.typeName, typeName))
+      ) {
         return true;
       }
       if (isArrayFieldType(allowedType)) {

--- a/server/gx-workflow-ls-format2/tests/integration/validation.test.ts
+++ b/server/gx-workflow-ls-format2/tests/integration/validation.test.ts
@@ -80,6 +80,37 @@ steps:
     );
   });
 
+  it("should not report error for compatible primitive types", async () => {
+    const content = `
+class: GalaxyWorkflow
+inputs:
+outputs:
+steps:
+    step:
+      position:
+        top: 0
+        left: 0
+    `;
+    const diagnostics = await validateDocument(content);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("should report error for incompatible primitive types", async () => {
+    const content = `
+class: GalaxyWorkflow
+inputs:
+outputs:
+steps:
+    step:
+      position:
+        top: "not a number"
+        left: 0
+    `;
+    const diagnostics = await validateDocument(content);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("Type mismatch for field 'top'. Expected 'float' but found 'string'.");
+  });
+
   describe("Custom Rules", () => {
     let rule: ValidationRule;
 


### PR DESCRIPTION
The primitive type doesn't need to match exactly, for example, `int` or `float` types in the schema can match `number` in the actual object.