### PR TITLE
Fix Format2 validation for `Any` type

### DIFF
--- a/server/gx-workflow-ls-format2/src/schema/definitions.ts
+++ b/server/gx-workflow-ls-format2/src/schema/definitions.ts
@@ -199,6 +199,10 @@ export class EnumSchemaNode implements SchemaNode {
     return this._schemaEnum.name;
   }
 
+  public matchesType(typeName: string): boolean {
+    return this.name === "Any" || this.symbols.includes(typeName);
+  }
+
   //Override toString for debugging purposes
   public toString(): string {
     return `EnumSchemaNode: ${this.name} - ${this.symbols}`;

--- a/server/gx-workflow-ls-format2/src/services/schemaValidationService.ts
+++ b/server/gx-workflow-ls-format2/src/services/schemaValidationService.ts
@@ -54,17 +54,20 @@ export class GxFormat2SchemaValidationService implements WorkflowValidator {
       }
     }
   }
+
   private validateEnumValue(
     node: StringASTNode,
-    schemaRecord: EnumSchemaNode,
+    enumSchemaNode: EnumSchemaNode,
     range: Range,
     diagnostics: Diagnostic[]
   ): void {
-    if (!schemaRecord.symbols.includes(node.value)) {
+    if (!enumSchemaNode.matchesType(node.value)) {
       diagnostics.push(
         Diagnostic.create(
           range,
-          `The value is not a valid '${schemaRecord.name}'. Allowed values are: ${schemaRecord.symbols.join(", ")}.`,
+          `The value is not a valid '${enumSchemaNode.name}'. Allowed values are: ${enumSchemaNode.symbols.join(
+            ", "
+          )}.`,
           DiagnosticSeverity.Error
         )
       );

--- a/server/gx-workflow-ls-format2/tests/integration/validation.test.ts
+++ b/server/gx-workflow-ls-format2/tests/integration/validation.test.ts
@@ -111,6 +111,21 @@ steps:
     expect(diagnostics[0].message).toContain("Type mismatch for field 'top'. Expected 'float' but found 'string'.");
   });
 
+  it("should not report error for properties with Any type", async () => {
+    const content = `
+class: GalaxyWorkflow
+inputs:
+outputs:
+steps:
+    step:
+      tool_state:
+        value: "any value"
+        another_value: 42
+    `;
+    const diagnostics = await validateDocument(content);
+    expect(diagnostics).toHaveLength(0);
+  });
+
   describe("Custom Rules", () => {
     let rule: ValidationRule;
 


### PR DESCRIPTION
It seems the type for [`Any` is defined as `Enum` in the gxformat2 schema](https://github.com/galaxyproject/gxformat2/blob/785cd40aeb308a2bcec836b40aa71a3169fbf1d9/schema/common/metaschema/metaschema_base.yml#L56).

This change will ensure that *any* type matches this *Enum* definition.

