### PR TITLE
Handle union types in Format2 Schema

### DIFF
--- a/server/gx-workflow-ls-format2/src/schema/schemaLoader.ts
+++ b/server/gx-workflow-ls-format2/src/schema/schemaLoader.ts
@@ -74,6 +74,9 @@ export class GalaxyWorkflowFormat2SchemaLoader implements GalaxyWorkflowSchemaLo
       enums: new Map<string, EnumSchemaNode>(),
       specializations: new Map<string, string>(),
       primitiveTypes: new Set<string>(),
+      isPrimitiveType: (type: string) => {
+        return definitions.primitiveTypes.has(type);
+      },
     };
 
     this.expandEntries(schemaEntries.values());

--- a/server/gx-workflow-ls-format2/src/schema/schemaNodeResolver.ts
+++ b/server/gx-workflow-ls-format2/src/schema/schemaNodeResolver.ts
@@ -32,8 +32,21 @@ export class SchemaNodeResolverImpl implements SchemaNodeResolver {
       if (currentSchemaNode instanceof RecordSchemaNode) {
         currentSchemaNode = currentSchemaNode.fields.find((f) => f.name === currentSegment);
       } else if (currentSchemaNode instanceof FieldSchemaNode) {
-        const typeNode = this.getSchemaNodeByTypeRef(currentSchemaNode.typeRef);
-        currentSchemaNode = typeNode;
+        if (currentSchemaNode.isUnionType) {
+          for (const typeRef of currentSchemaNode.typeRefs) {
+            const resolvedNode = this.getSchemaNodeByTypeRef(typeRef);
+            if (resolvedNode instanceof RecordSchemaNode) {
+              const matchedField = resolvedNode.fields.find((f) => f.name === currentSegment);
+              if (matchedField) {
+                currentSchemaNode = matchedField;
+                break;
+              }
+            }
+          }
+        } else {
+          const typeNode = this.getSchemaNodeByTypeRef(currentSchemaNode.typeRef);
+          currentSchemaNode = typeNode;
+        }
       }
       currentSegment = toWalk.shift();
     }

--- a/server/packages/server-common/src/utils.ts
+++ b/server/packages/server-common/src/utils.ts
@@ -34,9 +34,26 @@ export function isCompatibleType(expectedType: WorkflowDataType, actualType: str
   return isCompatible;
 }
 
+/**
+ * Check if the type is a valid workflow data type.
+ * @param type The type to check.
+ * @returns True if the type is a valid workflow data type.
+ */
 export function isWorkflowDataType(type?: string): type is WorkflowDataType {
   if (!type) {
     return false;
   }
   return type in workflowDataTypes;
+}
+
+const SIMPLE_TYPES = ["number", "string", "boolean", "null"];
+
+/**
+ * Check if the type is a simple type (i.e. number, string, boolean or null).
+ */
+export function isSimpleType(type?: string): boolean {
+  if (!type) {
+    return false;
+  }
+  return SIMPLE_TYPES.includes(type);
 }


### PR DESCRIPTION
Some elements in the gxformat2 schema can have multiple different types. For example, the `out` field of a `WorkflowStep` can be either of type `string` or `WorkflowStepOutput`.

https://github.com/galaxyproject/gxformat2/blob/785cd40aeb308a2bcec836b40aa71a3169fbf1d9/schema/v19_09/workflow.yml#L178

This PR will handle those union types and try to match them during schema node resolution, validation, and item completion.