### PR TITLE
Ignore auto-complete suggestions for some schema elements in Format2

### DIFF
--- a/server/gx-workflow-ls-format2/src/services/completionService.ts
+++ b/server/gx-workflow-ls-format2/src/services/completionService.ts
@@ -6,6 +6,12 @@ import { FieldSchemaNode, RecordSchemaNode, SchemaNode, SchemaNodeResolver } fro
 import { EnumSchemaNode } from "../schema/definitions";
 
 export class GxFormat2CompletionService {
+  /**
+   * Schema references that should be ignored when suggesting completions.
+   * These are typically user-defined names and we cannot suggest completions for them.
+   */
+  private readonly ignoredSchemaRefs = new Set(["InputParameter", "OutputParameter", "WorkflowStep"]);
+
   constructor(protected readonly schemaNodeResolver: SchemaNodeResolver) {}
 
   public doComplete(documentContext: GxFormat2WorkflowDocument, position: Position): Promise<CompletionList> {
@@ -108,6 +114,10 @@ export class GxFormat2CompletionService {
           if (typeNode === undefined) continue;
           result.push(...this.getProposedItems(typeNode, textBuffer, exclude, offset));
         }
+        return result;
+      }
+
+      if (this.ignoredSchemaRefs.has(schemaNode.typeRef)) {
         return result;
       }
 

--- a/server/gx-workflow-ls-format2/tests/integration/completion.test.ts
+++ b/server/gx-workflow-ls-format2/tests/integration/completion.test.ts
@@ -110,6 +110,45 @@ in$
     expect(completions?.items[0].label).toBe("inputs");
   });
 
+  it("should not suggest any properties when defining new workflow inputs", async () => {
+    const template = `
+class: GalaxyWorkflow
+inputs:
+  $
+`;
+    const { contents, position } = parseTemplate(template);
+
+    const completions = await getCompletions(contents, position);
+
+    expect(completions?.items.length).toBe(0);
+  });
+
+  it("should not suggest any properties when defining new workflow outputs", async () => {
+    const template = `
+class: GalaxyWorkflow
+outputs:
+  $
+`;
+    const { contents, position } = parseTemplate(template);
+
+    const completions = await getCompletions(contents, position);
+
+    expect(completions?.items.length).toBe(0);
+  });
+
+  it("should not suggest any properties when defining new workflow steps", async () => {
+    const template = `
+class: GalaxyWorkflow
+steps:
+  $
+`;
+    const { contents, position } = parseTemplate(template);
+
+    const completions = await getCompletions(contents, position);
+
+    expect(completions?.items.length).toBe(0);
+  });
+
   it("should not suggest property completions inlined with the definition", async () => {
     const template = `
 class: GalaxyWorkflow


### PR DESCRIPTION
Attempting to suggest values for `inputs`, `outputs`, and `steps` definitions will wrongly display suggestions for the actual properties of the items (i.e for inputs it will return `id`, `doc`, `type`, etc.) instead of letting the user define the item name first.

| Before | After |
|--------|-------|
| ![image](https://github.com/davelopez/galaxy-workflows-vscode/assets/46503462/81caf463-e7d7-41c2-b4e1-15d3766d3bcb)   | ![image](https://github.com/davelopez/galaxy-workflows-vscode/assets/46503462/19e450a1-fded-4f2f-8b6c-51ea19bd9fc2)  |


