### PR TITLE
Fix some completion edge cases in Format2

### DIFF
--- a/server/gx-workflow-ls-format2/src/schema/definitions.ts
+++ b/server/gx-workflow-ls-format2/src/schema/definitions.ts
@@ -195,12 +195,16 @@ export class EnumSchemaNode implements SchemaNode {
     return false;
   }
 
+  public get canBeAny(): boolean {
+    return this.name === "Any";
+  }
+
   public get typeRef(): string {
     return this._schemaEnum.name;
   }
 
   public matchesType(typeName: string): boolean {
-    return this.name === "Any" || this.symbols.includes(typeName);
+    return this.canBeAny || this.symbols.includes(typeName);
   }
 
   //Override toString for debugging purposes

--- a/server/gx-workflow-ls-format2/src/services/completionService.ts
+++ b/server/gx-workflow-ls-format2/src/services/completionService.ts
@@ -53,6 +53,8 @@ export class GxFormat2CompletionService {
     const position = textBuffer.getPosition(offset);
     const isPositionAfterColon = textBuffer.isPositionAfterToken(position, ":");
     if (schemaNode instanceof EnumSchemaNode) {
+      if (schemaNode.canBeAny) return result;
+
       schemaNode.symbols
         .filter((v) => v.startsWith(currentWord))
         .forEach((value) => {

--- a/server/gx-workflow-ls-format2/src/services/completionService.ts
+++ b/server/gx-workflow-ls-format2/src/services/completionService.ts
@@ -25,6 +25,12 @@ export class GxFormat2CompletionService {
     const offset = textBuffer.getOffsetAt(position);
     let node = nodeManager.getNodeFromOffset(offset);
 
+    if (node === undefined && !textBuffer.isEmpty()) {
+      // Do not suggest completions if we cannot find a node at the current position
+      // If the document is empty, we can still suggest the root properties
+      return Promise.resolve(result);
+    }
+
     const nodePath = nodeManager.getPathFromNode(node);
     let schemaNode = this.schemaNodeResolver.resolveSchemaContext(nodePath);
     if (schemaNode === undefined) {

--- a/server/gx-workflow-ls-format2/tests/integration/completion.test.ts
+++ b/server/gx-workflow-ls-format2/tests/integration/completion.test.ts
@@ -354,4 +354,16 @@ report:
     const completionLabels = getCompletionItemsLabels(completions);
     expect(completionLabels).toEqual(EXPECTED_COMPLETION_LABELS);
   });
+
+  it("should not suggest properties when the type of the property is 'Any'", async () => {
+    const template = `
+class: GalaxyWorkflow
+creator:
+  $`;
+    const { contents, position } = parseTemplate(template);
+
+    const completions = await getCompletions(contents, position);
+
+    expect(completions?.items).toHaveLength(0);
+  });
 });

--- a/server/gx-workflow-ls-format2/tests/integration/completion.test.ts
+++ b/server/gx-workflow-ls-format2/tests/integration/completion.test.ts
@@ -366,4 +366,18 @@ creator:
 
     expect(completions?.items).toHaveLength(0);
   });
+
+  it("should not suggest any properties when the indent is not correct", async () => {
+    const template = `
+class: GalaxyWorkflow
+inputs:
+  My input:
+      $`; // Incorrect indent
+
+    const { contents, position } = parseTemplate(template);
+
+    const completions = await getCompletions(contents, position);
+
+    expect(completions?.items).toHaveLength(0);
+  });
 });

--- a/server/packages/yaml-language-service/src/parser/yamlDocument.ts
+++ b/server/packages/yaml-language-service/src/parser/yamlDocument.ts
@@ -111,6 +111,7 @@ export class YAMLDocument implements ParsedDocument {
     if (indentation === 0) return this.root;
     const parentIndentation = Math.max(0, indentation - this._indentation);
     const parentLine = this._textBuffer.findPreviousLineWithSameIndentation(offset, parentIndentation);
+    if (parentLine === undefined) return undefined;
     const parentOffset = this._textBuffer.getOffsetAt(Position.create(parentLine, parentIndentation));
 
     const rootNode = this.root as ObjectASTNodeImpl;

--- a/server/packages/yaml-language-service/src/utils/textBuffer.ts
+++ b/server/packages/yaml-language-service/src/utils/textBuffer.ts
@@ -97,7 +97,7 @@ export class TextBuffer {
     return indentation;
   }
 
-  public findPreviousLineWithSameIndentation(offset: number, indentation: number): number {
+  public findPreviousLineWithSameIndentation(offset: number, indentation: number): number | undefined {
     const position = this.getPosition(offset);
     const indentationSpaces = " ".repeat(indentation);
     let currentLine = position.line - 1;
@@ -111,6 +111,9 @@ export class TextBuffer {
         currentLine--;
       }
     }
+    if (!found) {
+      return undefined;
+    }
     return currentLine;
   }
 
@@ -121,5 +124,9 @@ export class TextBuffer {
       return false; // No token found
     }
     return tokenIndex < position.character;
+  }
+
+  public isEmpty(): boolean {
+    return this.doc.getText().trim().length === 0;
   }
 }


### PR DESCRIPTION
- When the type of an element is `Any` no completion items should be suggested.
- If a line's indentation is incorrect, we should not suggest anything. Before this change, the root node in the schema was used by default which was confusing.