### PR TITLE
Update CI actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  push:
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Get version from tag
         id: get_version
-        uses: battila7/get-version-action@v2
+        uses: jannemattila/get-version-from-tag@v3
 
       - name: Create Release
         id: create_release
@@ -32,12 +32,12 @@ jobs:
 
             You can also manually install the extension by downloading the VSIX package included in this release and then running:
             ```
-            code --install-extension galaxy-workflows-${{ steps.get_version.outputs.version-without-v }}.vsix
+            code --install-extension galaxy-workflows-${{ steps.get_version.outputs.version }}.vsix
             ```
           draft: false
           prerelease: false
     outputs:
-      release_version: ${{ steps.get_version.outputs.version-without-v }}
+      release_version: ${{ steps.get_version.outputs.version }}
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}
 
   publish_release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   prepare_release:
-    name: Create Release
+    name: Prepare Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -16,6 +16,20 @@ jobs:
       - name: Get version from tag
         id: get_version
         uses: jannemattila/get-version-from-tag@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 21
+
+      - run: npm ci
+
+      - name: Package Extension
+        id: packageExtension
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: stub
+          dryRun: true
 
       - name: Create Draft Release
         id: create_release
@@ -36,9 +50,11 @@ jobs:
           draft: true
           prerelease: false
           generate_release_notes: true
+          files: ${{ steps.packageExtension.outputs.vsixPath }}
     outputs:
       release_version: ${{ steps.get_version.outputs.version }}
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}
+      vsixPath: ${{ steps.packageExtension.outputs.vsixPath }}
 
   publish_release:
     name: Publish extension to Open-VSX and VSCode Marketplace
@@ -53,37 +69,16 @@ jobs:
         with:
           node-version: 21
 
-      - name: Clean install dependencies
-        run: |
-          npm ci
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com
+          extensionFile: ${{ needs.prepare_release.outputs.vsixPath}}
 
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v1
         id: publishToOpenVSX
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          packagePath: "./"
-
-      - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v1
-        with:
-          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
-          registryUrl: https://marketplace.visualstudio.com
-          extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
-
-      - name: Upload vsix as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: galaxy-workflows-${{needs.prepare_release.outputs.release_version}}.vsix
-          path: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
-
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.prepare_release.outputs.release_upload_url }}
-          asset_path: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
-          asset_name: galaxy-workflows-${{needs.prepare_release.outputs.release_version}}.vsix
-          asset_content_type: application/vsix
+          extensionFile: ${{ needs.prepare_release.outputs.vsixPath}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         id: get_version
         uses: jannemattila/get-version-from-tag@v3
 
-      - name: Create Release
+      - name: Create Draft Release
         id: create_release
         uses: softprops/action-gh-release@v2
         env:
@@ -33,8 +33,9 @@ jobs:
             ```
             code --install-extension galaxy-workflows-${{ steps.get_version.outputs.version }}.vsix
             ```
-          draft: false
+          draft: true
           prerelease: false
+          generate_release_notes: true
     outputs:
       release_version: ${{ steps.get_version.outputs.version }}
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,11 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          name: Release ${{ github.ref }}
           body: |
             The Galaxy Workflows Extension is available at:
             - [Open VSX Registry](https://open-vsx.org/extension/davelopez/galaxy-workflows)


### PR DESCRIPTION
Replace some deprecated GitHub workflow actions with new ones and simplify the release workflow to reuse the same VSIX package.