### PR TITLE
Adapt launch and tasks configs to tsup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,10 +13,7 @@
       "smartStep": true,
       "sourceMaps": true,
       "preLaunchTask": "watch",
-      "resolveSourceMapLocations": ["${workspaceFolder}/client/dist/**/*.js"],
-      "sourceMapPathOverrides": {
-        "webpack://?:*/*": "${workspaceFolder}/client/*"
-      }
+      "resolveSourceMapLocations": ["${workspaceFolder}/client/dist/**/*.js"]
     },
     {
       "name": "Launch Extension in Webworker",
@@ -27,10 +24,7 @@
       "smartStep": true,
       "sourceMaps": true,
       "preLaunchTask": "watch",
-      "resolveSourceMapLocations": ["${workspaceFolder}/client/dist/**/*.js"],
-      "sourceMapPathOverrides": {
-        "webpack://?:*/*": "${workspaceFolder}/client/*"
-      }
+      "resolveSourceMapLocations": ["${workspaceFolder}/client/dist/**/*.js"]
     },
     {
       "name": "Attach to Native Server",
@@ -39,10 +33,7 @@
       "port": 6009,
       "sourceMaps": true,
       "smartStep": true,
-      "resolveSourceMapLocations": ["${workspaceFolder}/server/gx-workflow-ls-native/dist/**/*.js"],
-      "sourceMapPathOverrides": {
-        "webpack://?:*/*": "${workspaceFolder}/server/gx-workflow-ls-native/*"
-      }
+      "resolveSourceMapLocations": ["${workspaceFolder}/server/gx-workflow-ls-native/dist/**/*.js"]
     },
     {
       "name": "Attach to gxformat2 Server",
@@ -51,17 +42,23 @@
       "port": 6010,
       "sourceMaps": true,
       "smartStep": true,
-      "resolveSourceMapLocations": ["${workspaceFolder}/server/gx-workflow-ls-format2/dist/**/*.js"],
-      "sourceMapPathOverrides": {
-        "webpack://?:*/*": "${workspaceFolder}/server/gx-workflow-ls-format2/*"
-      }
+      "resolveSourceMapLocations": ["${workspaceFolder}/server/gx-workflow-ls-format2/dist/**/*.js"]
     },
     {
       "type": "node",
-      "name": "Debug Unit Tests",
+      "name": "Debug Server Unit Tests",
+      "program": "${workspaceFolder}/node_modules/vitest/vitest.mjs",
+      "request": "launch",
+      "args": ["run", "--dir", "server"],
+      "internalConsoleOptions": "openOnSessionStart",
+      "preLaunchTask": "watch"
+    },
+    {
+      "type": "node",
+      "name": "Debug Client Unit Tests",
       "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
       "request": "launch",
-      "args": ["-i"],
+      "args": ["-i", "--config", "client/jest.config.js"],
       "internalConsoleOptions": "openOnSessionStart",
       "preLaunchTask": "watch"
     },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,7 +13,7 @@
         "panel": "dedicated",
         "reveal": "never"
       },
-      "problemMatcher": ["$ts-webpack", "$tslint-webpack"]
+      "problemMatcher": ["$tsc"]
     },
     {
       "label": "watch",
@@ -29,7 +29,26 @@
         "panel": "dedicated",
         "reveal": "never"
       },
-      "problemMatcher": ["$ts-webpack-watch", "$tslint-webpack-watch"]
+      "problemMatcher": [
+        "$tsc-watch",
+        {
+          "owner": "tsup",
+          "source": "tsup",
+          "applyTo": "allDocuments",
+          "fileLocation": ["relative", "${workspaceFolder}"],
+          "pattern": {
+            "regexp": ".",
+            "file": 1,
+            "location": 2,
+            "message": 3
+          },
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": "CJS Build start|IIFE Build start",
+            "endsPattern": "Build success"
+          }
+        }
+      ]
     },
     {
       "label": "test-compile",
@@ -40,7 +59,7 @@
         "panel": "dedicated",
         "reveal": "never"
       },
-      "problemMatcher": ["$ts-webpack", "$tslint-webpack"]
+      "problemMatcher": ["$tsc"]
     }
   ]
 }


### PR DESCRIPTION
This cleans up some leftovers from `webpack->tsub` migration and fixes debugging with breakpoints directly in VSCode with "Debug Extension + Servers" (F5)