### PR TITLE
fix(web): tool auto-resolution + workspace-scoped ToolShed URL (on top of #91)

### DIFF
--- a/client/src/browser/extension.ts
+++ b/client/src/browser/extension.ts
@@ -27,7 +27,9 @@ export async function deactivate(): Promise<void> {
 
 function createWebWorkerLanguageClient(languageIds: string[], serverUri: Uri): LanguageClient {
   const documentSelector = languageIds.map((languageId) => ({ language: languageId }));
-  const clientOptions: LanguageClientOptions = buildBasicLanguageClientOptions(documentSelector);
+  const clientOptions: LanguageClientOptions = buildBasicLanguageClientOptions(documentSelector, {
+    toolAutoResolution: true,
+  });
   const worker = new Worker(serverUri.toString());
   return new LanguageClient(
     `${languageIds}-language-client`,

--- a/client/tests/e2e/suite/extension.ga.e2e.ts
+++ b/client/tests/e2e/suite/extension.ga.e2e.ts
@@ -57,27 +57,42 @@ suite("Native (JSON) Workflows", () => {
         // A prior test may have an in-flight auto-resolution whose completion
         // races useEmptyCache() and lands in the fresh cache dir — so don't
         // assert `initial === 0`. Record the baseline and assert growth.
-        const initial = await api.nativeClient.sendRequest<{ cacheSize: number }>(
+        const initial = await api.nativeClient.sendRequest<{ cacheSize: number; autoResolutionEnabled: boolean }>(
           "galaxy-workflows-ls.getToolCacheStatus"
         );
 
-        const dirtyUri = getDocUri(path.join("json", "clean", "iwc_fastp_multiqc_dirty.ga"));
-        await activateAndOpenInEditor(dirtyUri);
+        // Network-independent guard: if the gate is off, auto-resolution can
+        // never fire and the test below would silently skip as "offline",
+        // masking the real bug. Fail loudly instead.
+        assert.strictEqual(
+          initial.autoResolutionEnabled,
+          true,
+          "auto-resolution gate is off — the native client must send toolAutoResolution:true"
+        );
 
-        // Auto-resolution: onDidOpen → scheduleResolution → 300ms debounce →
-        // populateCache → ToolShed fetch → cacheSize grows by the 2 IWC tools.
-        const target = initial.cacheSize + 2;
-        const deadline = Date.now() + 30_000;
-        let status = initial;
-        while (Date.now() < deadline && status.cacheSize < target) {
-          await sleep(500);
-          status = await api.nativeClient.sendRequest("galaxy-workflows-ls.getToolCacheStatus");
-        }
-        if (status.cacheSize < target) {
-          console.warn(`Auto-population incomplete (offline?), cacheSize=${status.cacheSize} target=${target}`);
-          this.skip();
-        }
-        assert.ok(status.cacheSize >= target, `expected cacheSize >= ${target}, got ${status.cacheSize}`);
+        // Open a fresh temp copy, not the shared fixture URI. Auto-resolution is
+        // driven by onDidOpen, which VS Code only fires for a genuinely new
+        // document — reopening an already-open URI reuses it silently and the
+        // resolution never runs (that was the original "silently skips" symptom).
+        const dirtyUri = getDocUri(path.join("json", "clean", "iwc_fastp_multiqc_dirty.ga"));
+        await withTempFixture(dirtyUri, async (tempUri) => {
+          await activateAndOpenInEditor(tempUri);
+
+          // Auto-resolution: onDidOpen → scheduleResolution → 300ms debounce →
+          // populateCache → ToolShed fetch → cacheSize grows by the 2 IWC tools.
+          const target = initial.cacheSize + 2;
+          const deadline = Date.now() + 30_000;
+          let status = initial;
+          while (Date.now() < deadline && status.cacheSize < target) {
+            await sleep(500);
+            status = await api.nativeClient.sendRequest("galaxy-workflows-ls.getToolCacheStatus");
+          }
+          if (status.cacheSize < target) {
+            console.warn(`Auto-population incomplete (offline?), cacheSize=${status.cacheSize} target=${target}`);
+            this.skip();
+          }
+          assert.ok(status.cacheSize >= target, `expected cacheSize >= ${target}, got ${status.cacheSize}`);
+        });
       });
     });
 

--- a/client/tests/e2e/suite/extension.gxformat2.e2e.ts
+++ b/client/tests/e2e/suite/extension.gxformat2.e2e.ts
@@ -12,6 +12,7 @@ import {
   sleep,
   updateSettings,
   waitForDiagnostics,
+  waitForDiagnosticGone,
   waitForDiagnosticMatching,
 } from "./helpers";
 import { useEmptyCache, usePopulatedCache } from "./cacheHelpers";
@@ -106,6 +107,17 @@ suite("Format2 (YAML) Workflows", () => {
         },
       ]);
     });
+  });
+
+  suite("IWC validation profile (populated cache)", function () {
+    // The fixture's cat1 step resolves against the populated cache, so the only
+    // diagnostics under each profile come from the profile rules themselves.
+    usePopulatedCache([{ toolId: "cat1", toolVersion: "1.0.0" }]);
+    beforeEach(async () => {
+      // usePopulatedCache sets the cache dir; only the profile needs resetting here.
+      await updateSettings("validation.profile", undefined);
+      await sleep(500);
+    });
 
     test("Changing validation profile shows IWC diagnostics then clears on reset", async () => {
       // Fixture satisfies schema (inputs/outputs/steps present) but omits the
@@ -133,8 +145,9 @@ suite("Format2 (YAML) Workflows", () => {
       assert.strictEqual(creator!.severity, vscode.DiagnosticSeverity.Warning);
       assert.strictEqual(license!.severity, vscode.DiagnosticSeverity.Warning);
 
-      await resetSettings();
-      await waitForDiagnostics(docUri);
+      // Reset only the profile; keep the populated cache so the step stays resolved.
+      await updateSettings("validation.profile", undefined);
+      await waitForDiagnosticGone(docUri, (d) => d.message.includes("must have a release version"));
       await assertDiagnostics(docUri, []); // clean again
     });
   });

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
           },
           "galaxyWorkflows.toolShed.url": {
             "markdownDescription": "ToolShed URL used to fetch tool definitions on cache miss.",
-            "scope": "machine",
+            "scope": "window",
             "type": "string",
             "default": "https://toolshed.g2.bx.psu.edu"
           }

--- a/package.json
+++ b/package.json
@@ -462,9 +462,9 @@
       "esbuild"
     ],
     "overrides": {
-      "@galaxy-tool-util/core": "1.8.0",
-      "@galaxy-tool-util/schema": "1.8.0",
-      "@galaxy-tool-util/search": "1.8.0"
+      "@galaxy-tool-util/core": "1.8.2",
+      "@galaxy-tool-util/schema": "1.8.2",
+      "@galaxy-tool-util/search": "1.8.2"
     }
   },
   "__metadata": {

--- a/package.json
+++ b/package.json
@@ -462,9 +462,9 @@
       "esbuild"
     ],
     "overrides": {
-      "@galaxy-tool-util/core": "1.1.0",
-      "@galaxy-tool-util/schema": "1.1.0",
-      "@galaxy-tool-util/search": "1.1.0"
+      "@galaxy-tool-util/core": "1.8.0",
+      "@galaxy-tool-util/schema": "1.8.0",
+      "@galaxy-tool-util/search": "1.8.0"
     }
   },
   "__metadata": {

--- a/package.json
+++ b/package.json
@@ -462,9 +462,9 @@
       "esbuild"
     ],
     "overrides": {
-      "@galaxy-tool-util/core": "1.8.2",
-      "@galaxy-tool-util/schema": "1.8.2",
-      "@galaxy-tool-util/search": "1.8.2"
+      "@galaxy-tool-util/core": "1.9.0",
+      "@galaxy-tool-util/schema": "1.9.0",
+      "@galaxy-tool-util/search": "1.9.0"
     }
   },
   "__metadata": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@galaxy-tool-util/core': 1.8.0
-  '@galaxy-tool-util/schema': 1.8.0
-  '@galaxy-tool-util/search': 1.8.0
+  '@galaxy-tool-util/core': 1.8.2
+  '@galaxy-tool-util/schema': 1.8.2
+  '@galaxy-tool-util/search': 1.8.2
 
 importers:
 
@@ -126,11 +126,11 @@ importers:
   server/gx-workflow-ls-format2:
     dependencies:
       '@galaxy-tool-util/core':
-        specifier: 1.8.0
-        version: 1.8.0
+        specifier: 1.8.2
+        version: 1.8.2
       '@galaxy-tool-util/schema':
-        specifier: 1.8.0
-        version: 1.8.0
+        specifier: 1.8.2
+        version: 1.8.2
       '@gxwf/server-common':
         specifier: workspace:*
         version: link:../packages/server-common
@@ -172,11 +172,11 @@ importers:
   server/gx-workflow-ls-native:
     dependencies:
       '@galaxy-tool-util/core':
-        specifier: 1.8.0
-        version: 1.8.0
+        specifier: 1.8.2
+        version: 1.8.2
       '@galaxy-tool-util/schema':
-        specifier: 1.8.0
-        version: 1.8.0
+        specifier: 1.8.2
+        version: 1.8.2
       '@gxwf/server-common':
         specifier: workspace:*
         version: link:../packages/server-common
@@ -224,14 +224,14 @@ importers:
   server/packages/server-common:
     dependencies:
       '@galaxy-tool-util/core':
-        specifier: 1.8.0
-        version: 1.8.0
+        specifier: 1.8.2
+        version: 1.8.2
       '@galaxy-tool-util/schema':
-        specifier: 1.8.0
-        version: 1.8.0
+        specifier: 1.8.2
+        version: 1.8.2
       '@galaxy-tool-util/search':
-        specifier: 1.8.0
-        version: 1.8.0
+        specifier: 1.8.2
+        version: 1.8.2
       '@types/node':
         specifier: ^20.5.7
         version: 20.19.39
@@ -260,8 +260,8 @@ importers:
   server/packages/workflow-tests-language-service:
     dependencies:
       '@galaxy-tool-util/schema':
-        specifier: 1.8.0
-        version: 1.8.0
+        specifier: 1.8.2
+        version: 1.8.2
       '@gxwf/server-common':
         specifier: workspace:*
         version: link:../server-common
@@ -685,14 +685,14 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@galaxy-tool-util/core@1.8.0':
-    resolution: {integrity: sha512-R5Hu9qAW2+QyQd0q7wFDm6kSwzoIMMQx1IZXjIg1Nh/waftqL45j+fSgNxUT3AjYvmczBDhobinuGK2WSbo/Ow==}
+  '@galaxy-tool-util/core@1.8.2':
+    resolution: {integrity: sha512-+a7UPs/Qo+7y81XH2JWX4BX1TRCi2/5ZkKbMHbpv5dpM06mTdyGhT/osSyJ+7nhVHknz81VR8ezOZbEaRIpv+Q==}
 
-  '@galaxy-tool-util/schema@1.8.0':
-    resolution: {integrity: sha512-aFkaG/tde24nfY7XgjHouSGHwdi2wGlOuGNoIdxWssxbDwqkCg902DabkL8L4fVnj3JKjrduGz/FzgE/t66p+A==}
+  '@galaxy-tool-util/schema@1.8.2':
+    resolution: {integrity: sha512-Vfg0W1idxuvUKnnWgv8brphm6j9VMFJ755Iou8kdrjQViyuW7aYQ4aepqfuwT0IBdb6ALoJGTbN4OOzMDl5KGA==}
 
-  '@galaxy-tool-util/search@1.8.0':
-    resolution: {integrity: sha512-vYSPKUgZBdtZg+fvrboUdi38NWrRRHm7kdzsAcgqAe5MTDyQ23x+rJYcNn+5f4sRxCo0pTSmZ9xA4e5FrYj+5g==}
+  '@galaxy-tool-util/search@1.8.2':
+    resolution: {integrity: sha512-iML47Luzvbe+CVc5EeGSOrSv/F5bOCHH8iBFLcpIhoalG5L+Dpw9iRh907k/LqHzEdlZWE38Xqa0cUzExIRwZw==}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -4330,23 +4330,23 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
-  '@galaxy-tool-util/core@1.8.0':
+  '@galaxy-tool-util/core@1.8.2':
     dependencies:
-      '@galaxy-tool-util/schema': 1.8.0
+      '@galaxy-tool-util/schema': 1.8.2
       effect: 3.21.2
       yaml: 2.8.3
 
-  '@galaxy-tool-util/schema@1.8.0':
+  '@galaxy-tool-util/schema@1.8.2':
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       effect: 3.21.2
       yaml: 2.8.3
 
-  '@galaxy-tool-util/search@1.8.0':
+  '@galaxy-tool-util/search@1.8.2':
     dependencies:
-      '@galaxy-tool-util/core': 1.8.0
-      '@galaxy-tool-util/schema': 1.8.0
+      '@galaxy-tool-util/core': 1.8.2
+      '@galaxy-tool-util/schema': 1.8.2
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@galaxy-tool-util/core': 1.1.0
-  '@galaxy-tool-util/schema': 1.1.0
-  '@galaxy-tool-util/search': 1.1.0
+  '@galaxy-tool-util/core': 1.8.0
+  '@galaxy-tool-util/schema': 1.8.0
+  '@galaxy-tool-util/search': 1.8.0
 
 importers:
 
@@ -126,11 +126,11 @@ importers:
   server/gx-workflow-ls-format2:
     dependencies:
       '@galaxy-tool-util/core':
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.8.0
+        version: 1.8.0
       '@galaxy-tool-util/schema':
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.8.0
+        version: 1.8.0
       '@gxwf/server-common':
         specifier: workspace:*
         version: link:../packages/server-common
@@ -172,11 +172,11 @@ importers:
   server/gx-workflow-ls-native:
     dependencies:
       '@galaxy-tool-util/core':
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.8.0
+        version: 1.8.0
       '@galaxy-tool-util/schema':
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.8.0
+        version: 1.8.0
       '@gxwf/server-common':
         specifier: workspace:*
         version: link:../packages/server-common
@@ -224,14 +224,14 @@ importers:
   server/packages/server-common:
     dependencies:
       '@galaxy-tool-util/core':
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.8.0
+        version: 1.8.0
       '@galaxy-tool-util/schema':
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.8.0
+        version: 1.8.0
       '@galaxy-tool-util/search':
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.8.0
+        version: 1.8.0
       '@types/node':
         specifier: ^20.5.7
         version: 20.19.39
@@ -260,8 +260,8 @@ importers:
   server/packages/workflow-tests-language-service:
     dependencies:
       '@galaxy-tool-util/schema':
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.8.0
+        version: 1.8.0
       '@gxwf/server-common':
         specifier: workspace:*
         version: link:../server-common
@@ -685,14 +685,14 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@galaxy-tool-util/core@1.1.0':
-    resolution: {integrity: sha512-aOCt4s3bW8OYRrt2JPjtkS8pn2yTPJy86eED6lh3Nfy/KaFWMDUcXBjTm+5/7BgmcfW9x/d/6FVazsekH07OVg==}
+  '@galaxy-tool-util/core@1.8.0':
+    resolution: {integrity: sha512-R5Hu9qAW2+QyQd0q7wFDm6kSwzoIMMQx1IZXjIg1Nh/waftqL45j+fSgNxUT3AjYvmczBDhobinuGK2WSbo/Ow==}
 
-  '@galaxy-tool-util/schema@1.1.0':
-    resolution: {integrity: sha512-D0dMtBaTyRJhoAxH1Djx/42WnxQDAk3yuMhTd3k+MCez1jiGL1kFeYDQEk8yWSgY5Z4d+u24wbhaWG4Q2GTG1w==}
+  '@galaxy-tool-util/schema@1.8.0':
+    resolution: {integrity: sha512-aFkaG/tde24nfY7XgjHouSGHwdi2wGlOuGNoIdxWssxbDwqkCg902DabkL8L4fVnj3JKjrduGz/FzgE/t66p+A==}
 
-  '@galaxy-tool-util/search@1.1.0':
-    resolution: {integrity: sha512-VSLDCUE68u/2+zKWH8J+wf0N080vOUDJd/nVFr5v7F81TJURjdC4oHRsl2YYs2Uwb8JkpWIvs9EAbtSB2rzF2g==}
+  '@galaxy-tool-util/search@1.8.0':
+    resolution: {integrity: sha512-vYSPKUgZBdtZg+fvrboUdi38NWrRRHm7kdzsAcgqAe5MTDyQ23x+rJYcNn+5f4sRxCo0pTSmZ9xA4e5FrYj+5g==}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -4330,23 +4330,23 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
-  '@galaxy-tool-util/core@1.1.0':
+  '@galaxy-tool-util/core@1.8.0':
     dependencies:
-      '@galaxy-tool-util/schema': 1.1.0
+      '@galaxy-tool-util/schema': 1.8.0
       effect: 3.21.2
       yaml: 2.8.3
 
-  '@galaxy-tool-util/schema@1.1.0':
+  '@galaxy-tool-util/schema@1.8.0':
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       effect: 3.21.2
       yaml: 2.8.3
 
-  '@galaxy-tool-util/search@1.1.0':
+  '@galaxy-tool-util/search@1.8.0':
     dependencies:
-      '@galaxy-tool-util/core': 1.1.0
-      '@galaxy-tool-util/schema': 1.1.0
+      '@galaxy-tool-util/core': 1.8.0
+      '@galaxy-tool-util/schema': 1.8.0
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@galaxy-tool-util/core': 1.8.2
-  '@galaxy-tool-util/schema': 1.8.2
-  '@galaxy-tool-util/search': 1.8.2
+  '@galaxy-tool-util/core': 1.9.0
+  '@galaxy-tool-util/schema': 1.9.0
+  '@galaxy-tool-util/search': 1.9.0
 
 importers:
 
@@ -126,11 +126,11 @@ importers:
   server/gx-workflow-ls-format2:
     dependencies:
       '@galaxy-tool-util/core':
-        specifier: 1.8.2
-        version: 1.8.2
+        specifier: 1.9.0
+        version: 1.9.0
       '@galaxy-tool-util/schema':
-        specifier: 1.8.2
-        version: 1.8.2
+        specifier: 1.9.0
+        version: 1.9.0
       '@gxwf/server-common':
         specifier: workspace:*
         version: link:../packages/server-common
@@ -172,11 +172,11 @@ importers:
   server/gx-workflow-ls-native:
     dependencies:
       '@galaxy-tool-util/core':
-        specifier: 1.8.2
-        version: 1.8.2
+        specifier: 1.9.0
+        version: 1.9.0
       '@galaxy-tool-util/schema':
-        specifier: 1.8.2
-        version: 1.8.2
+        specifier: 1.9.0
+        version: 1.9.0
       '@gxwf/server-common':
         specifier: workspace:*
         version: link:../packages/server-common
@@ -224,14 +224,14 @@ importers:
   server/packages/server-common:
     dependencies:
       '@galaxy-tool-util/core':
-        specifier: 1.8.2
-        version: 1.8.2
+        specifier: 1.9.0
+        version: 1.9.0
       '@galaxy-tool-util/schema':
-        specifier: 1.8.2
-        version: 1.8.2
+        specifier: 1.9.0
+        version: 1.9.0
       '@galaxy-tool-util/search':
-        specifier: 1.8.2
-        version: 1.8.2
+        specifier: 1.9.0
+        version: 1.9.0
       '@types/node':
         specifier: ^20.5.7
         version: 20.19.39
@@ -260,8 +260,8 @@ importers:
   server/packages/workflow-tests-language-service:
     dependencies:
       '@galaxy-tool-util/schema':
-        specifier: 1.8.2
-        version: 1.8.2
+        specifier: 1.9.0
+        version: 1.9.0
       '@gxwf/server-common':
         specifier: workspace:*
         version: link:../server-common
@@ -685,14 +685,14 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@galaxy-tool-util/core@1.8.2':
-    resolution: {integrity: sha512-+a7UPs/Qo+7y81XH2JWX4BX1TRCi2/5ZkKbMHbpv5dpM06mTdyGhT/osSyJ+7nhVHknz81VR8ezOZbEaRIpv+Q==}
+  '@galaxy-tool-util/core@1.9.0':
+    resolution: {integrity: sha512-LF55iXan6JlhUXfBlsSlWamcJijm4HsM0/jAKyg7YirYjQTCkrWRJGQYkd0zZ/rINiPvALgr8mYxtBmYLNtH0A==}
 
-  '@galaxy-tool-util/schema@1.8.2':
-    resolution: {integrity: sha512-Vfg0W1idxuvUKnnWgv8brphm6j9VMFJ755Iou8kdrjQViyuW7aYQ4aepqfuwT0IBdb6ALoJGTbN4OOzMDl5KGA==}
+  '@galaxy-tool-util/schema@1.9.0':
+    resolution: {integrity: sha512-GCNfi04DqJkqWPu7WGrQ0Wdw6o/q12rTPdlv9ENUCavew/TUpIv+BvqkBVT54q+mSJ+VLJKtBA3zbR1O5PH6FQ==}
 
-  '@galaxy-tool-util/search@1.8.2':
-    resolution: {integrity: sha512-iML47Luzvbe+CVc5EeGSOrSv/F5bOCHH8iBFLcpIhoalG5L+Dpw9iRh907k/LqHzEdlZWE38Xqa0cUzExIRwZw==}
+  '@galaxy-tool-util/search@1.9.0':
+    resolution: {integrity: sha512-Ol29hfNWCJYv8hO4Oyb4UntRGUzwtJfJLadNsJNvSLtFAY+csMH9tKEnzt7Xstx08agdClgnmSXJo3DWmntXlQ==}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -4330,23 +4330,23 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
-  '@galaxy-tool-util/core@1.8.2':
+  '@galaxy-tool-util/core@1.9.0':
     dependencies:
-      '@galaxy-tool-util/schema': 1.8.2
+      '@galaxy-tool-util/schema': 1.9.0
       effect: 3.21.2
       yaml: 2.8.3
 
-  '@galaxy-tool-util/schema@1.8.2':
+  '@galaxy-tool-util/schema@1.9.0':
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       effect: 3.21.2
       yaml: 2.8.3
 
-  '@galaxy-tool-util/search@1.8.2':
+  '@galaxy-tool-util/search@1.9.0':
     dependencies:
-      '@galaxy-tool-util/core': 1.8.2
-      '@galaxy-tool-util/schema': 1.8.2
+      '@galaxy-tool-util/core': 1.9.0
+      '@galaxy-tool-util/schema': 1.9.0
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:

--- a/server/gx-workflow-ls-format2/package.json
+++ b/server/gx-workflow-ls-format2/package.json
@@ -5,8 +5,8 @@
   "author": "davelopez",
   "license": "MIT",
   "dependencies": {
-    "@galaxy-tool-util/core": "^1.8.0",
-    "@galaxy-tool-util/schema": "^1.8.0",
+    "@galaxy-tool-util/core": "^1.8.2",
+    "@galaxy-tool-util/schema": "^1.8.2",
     "yaml": "^2.8.3",
     "@gxwf/server-common": "workspace:*",
     "@gxwf/workflow-tests-language-service": "workspace:*",

--- a/server/gx-workflow-ls-format2/package.json
+++ b/server/gx-workflow-ls-format2/package.json
@@ -5,8 +5,8 @@
   "author": "davelopez",
   "license": "MIT",
   "dependencies": {
-    "@galaxy-tool-util/core": "^1.1.0",
-    "@galaxy-tool-util/schema": "^1.1.0",
+    "@galaxy-tool-util/core": "^1.8.0",
+    "@galaxy-tool-util/schema": "^1.8.0",
     "yaml": "^2.8.3",
     "@gxwf/server-common": "workspace:*",
     "@gxwf/workflow-tests-language-service": "workspace:*",

--- a/server/gx-workflow-ls-format2/package.json
+++ b/server/gx-workflow-ls-format2/package.json
@@ -5,8 +5,8 @@
   "author": "davelopez",
   "license": "MIT",
   "dependencies": {
-    "@galaxy-tool-util/core": "^1.8.2",
-    "@galaxy-tool-util/schema": "^1.8.2",
+    "@galaxy-tool-util/core": "^1.9.0",
+    "@galaxy-tool-util/schema": "^1.9.0",
     "yaml": "^2.8.3",
     "@gxwf/server-common": "workspace:*",
     "@gxwf/workflow-tests-language-service": "workspace:*",

--- a/server/gx-workflow-ls-format2/src/services/toolStateValidationService.ts
+++ b/server/gx-workflow-ls-format2/src/services/toolStateValidationService.ts
@@ -1,10 +1,11 @@
 import type { ToolRegistryService } from "@gxwf/server-common/src/languageTypes";
 import { astObjectNodeToRecord } from "@gxwf/server-common/src/providers/validation/toolStateAstHelpers";
 import { runObjectStateValidationLoop } from "@gxwf/server-common/src/providers/validation/toolStateValidation";
-import { validateFormat2StepStateStrict } from "@galaxy-tool-util/schema";
+import { nativeConnectionsFromFormat2In, validateFormat2StepStateStrict } from "@galaxy-tool-util/schema";
 import { Diagnostic } from "vscode-languageserver-types";
 import { GxFormat2WorkflowDocument } from "../gxFormat2WorkflowDocument";
 import type { ToolParam } from "./toolStateTypes";
+import { getFormat2StepInputs } from "./workflowConnectionService";
 
 export class ToolStateValidationService {
   constructor(private readonly toolRegistryService: ToolRegistryService) {}
@@ -13,10 +14,22 @@ export class ToolStateValidationService {
     return runObjectStateValidationLoop(
       documentContext.nodeManager,
       this.toolRegistryService,
-      async (toolId, toolVersion, stateValueNode) => {
+      async (toolId, toolVersion, stateValueNode, stepNode, stateKey) => {
+        const stateDict = astObjectNodeToRecord(stateValueNode);
+        // Pick the validator by state shape, not workflow format (mirrors gxformat2's
+        // state_encode_to_format2 contract): a raw native `tool_state` block keeps the
+        // native encoding (inline ConnectedValue/RuntimeValue markers, double-encoded
+        // scalars), so it must validate against the native model. A schema-aware `state`
+        // block validates against the format2 model.
+        if (stateKey === "tool_state") {
+          // A required param connected via the format2 `in:` block has no inline value
+          // in the native tool_state; tell the validator about those connections so it
+          // doesn't flag them as missing.
+          const connections = nativeConnectionsFromFormat2In(getFormat2StepInputs(stepNode));
+          return this.toolRegistryService.validateNativeStep(toolId, toolVersion, stateDict, connections);
+        }
         const rawParams = await this.toolRegistryService.getToolParameters(toolId, toolVersion);
         if (!rawParams) return [];
-        const stateDict = astObjectNodeToRecord(stateValueNode);
         return validateFormat2StepStateStrict(rawParams as ToolParam[], stateDict);
       }
     );

--- a/server/gx-workflow-ls-format2/src/services/workflowConnectionService.ts
+++ b/server/gx-workflow-ls-format2/src/services/workflowConnectionService.ts
@@ -1,8 +1,23 @@
 import { NodePath, ObjectASTNode, ArrayASTNode } from "@gxwf/server-common/src/ast/types";
+import { getNodeValue } from "@gxwf/server-common/src/ast/utils";
+import { normalizeStepIn, normalizeStepOut, type NormalizedFormat2StepInput } from "@galaxy-tool-util/schema";
 import { GxFormat2WorkflowDocument } from "../gxFormat2WorkflowDocument";
 
 export interface SourceInPath {
   stepName: string;
+}
+
+/**
+ * Expand a step's `in:` block into normalized {id, source, ...} connection
+ * entries, delegating to the canonical gxformat2 shorthand expander so every
+ * accepted form is covered (explicit list, map-to-string, map-to-object, and
+ * map-to-list multi-source). Used to tell the native tool_state validator which
+ * required params are satisfied by a connection rather than an inline value.
+ */
+export function getFormat2StepInputs(stepNode: ObjectASTNode): NormalizedFormat2StepInput[] {
+  const inNode = stepNode.properties.find((p) => String(p.keyNode.value) === "in")?.valueNode;
+  if (!inNode) return [];
+  return normalizeStepIn(getNodeValue(inNode));
 }
 
 /**
@@ -36,19 +51,50 @@ export function findSourceInPath(path: NodePath): SourceInPath | undefined {
   return undefined;
 }
 
+interface OrderedStep {
+  /** Step label — the map key (map form) or the `label:` property (list form). */
+  label: string | undefined;
+  stepNode: ObjectASTNode;
+}
+
+/**
+ * Return workflow steps in document order, regardless of whether `steps` is a
+ * map (keyed by label) or a list (array of step objects with a `label:`).
+ */
+function getOrderedSteps(stepsValue: ObjectASTNode | ArrayASTNode): OrderedStep[] {
+  const steps: OrderedStep[] = [];
+  if (stepsValue.type === "object") {
+    for (const stepProp of stepsValue.properties) {
+      if (stepProp.valueNode?.type === "object") {
+        steps.push({ label: String(stepProp.keyNode.value), stepNode: stepProp.valueNode as ObjectASTNode });
+      }
+    }
+  } else {
+    for (const item of stepsValue.items) {
+      if (item.type !== "object") continue;
+      const labelProp = (item as ObjectASTNode).properties.find((p) => String(p.keyNode.value) === "label");
+      const label = labelProp?.valueNode?.type === "string" ? String(labelProp.valueNode.value) : undefined;
+      steps.push({ label, stepNode: item as ObjectASTNode });
+    }
+  }
+  return steps;
+}
+
 /**
  * Returns all source strings available at the cursor step:
  *   - Workflow-level input names (e.g. "my_input")
- *   - Outputs from steps defined BEFORE `currentStepName` in YAML order,
+ *   - Outputs from steps defined BEFORE the current step in document order,
  *     in "step_label/output_name" form
  *
- * YAML property order is the authoritative step order in gxformat2, so
- * iteration stops at the current step to prevent forward references.
+ * Document order is the authoritative step order in gxformat2, so iteration
+ * stops at the current step to prevent forward references. `currentStep`
+ * identifies that step as either its label (map form) or its array index as a
+ * string (list form) — whichever `findSourceInPath` extracted from the path.
  *
  * Handles all `out:` forms: array of strings, array of objects (with `id`),
  * and object/mapping (keys are output names).
  */
-export function getAvailableSources(documentContext: GxFormat2WorkflowDocument, currentStepName: string): string[] {
+export function getAvailableSources(documentContext: GxFormat2WorkflowDocument, currentStep: string): string[] {
   const sources: string[] = [];
   const nodeManager = documentContext.nodeManager;
 
@@ -57,40 +103,30 @@ export function getAvailableSources(documentContext: GxFormat2WorkflowDocument, 
     sources.push(String(inputNode.keyNode.value));
   }
 
-  // Step outputs from steps defined before the current step (YAML order)
+  // Step outputs from steps defined before the current step (document order)
   const stepsProperty = nodeManager.getNodeFromPath("steps");
-  if (stepsProperty?.type !== "property" || stepsProperty.valueNode?.type !== "object") {
+  if (
+    stepsProperty?.type !== "property" ||
+    (stepsProperty.valueNode?.type !== "object" && stepsProperty.valueNode?.type !== "array")
+  ) {
     return sources;
   }
 
-  for (const stepProp of (stepsProperty.valueNode as ObjectASTNode).properties) {
-    const stepLabel = String(stepProp.keyNode.value);
-    if (stepLabel === currentStepName) break; // stop at current step — no forward references
-
-    const stepNode = stepProp.valueNode;
-    if (!stepNode || stepNode.type !== "object") continue;
+  const orderedSteps = getOrderedSteps(stepsProperty.valueNode as ObjectASTNode | ArrayASTNode);
+  for (let i = 0; i < orderedSteps.length; i++) {
+    const { label, stepNode } = orderedSteps[i];
+    // Stop at the current step — no forward references. Match by label (map
+    // form) or array index (list form, where currentStep is the index string).
+    if (label === currentStep || String(i) === currentStep) break;
+    if (!label) continue; // an unlabeled list step can't be referenced as a source
 
     const outProp = stepNode.properties.find((p) => String(p.keyNode.value) === "out");
     if (!outProp?.valueNode) continue;
 
-    const outNode = outProp.valueNode;
-    if (outNode.type === "array") {
-      for (const item of (outNode as ArrayASTNode).items) {
-        if (item.type === "string") {
-          sources.push(`${stepLabel}/${String(item.value)}`);
-        } else if (item.type === "object") {
-          // Array-of-objects form: out: [{id: "out1", hide: true}]
-          const idProp = (item as ObjectASTNode).properties.find((p) => String(p.keyNode.value) === "id");
-          if (idProp?.valueNode?.type === "string") {
-            sources.push(`${stepLabel}/${String(idProp.valueNode.value)}`);
-          }
-        }
-      }
-    } else if (outNode.type === "object") {
-      // Object/mapping form: out: {out_file1: {hide: true}, out_file2: {}}
-      for (const prop of (outNode as ObjectASTNode).properties) {
-        sources.push(`${stepLabel}/${String(prop.keyNode.value)}`);
-      }
+    // Delegate every `out:` shorthand (array-of-strings, array-of-objects,
+    // mapping) to the canonical expander rather than re-deriving the rules.
+    for (const out of normalizeStepOut(getNodeValue(outProp.valueNode))) {
+      if (out.id) sources.push(`${label}/${out.id}`);
     }
   }
 

--- a/server/gx-workflow-ls-format2/tests/integration/format2NativeToolStateValidation.test.ts
+++ b/server/gx-workflow-ls-format2/tests/integration/format2NativeToolStateValidation.test.ts
@@ -1,0 +1,194 @@
+/**
+ * gap 2 (mirrors jmchilton/galaxy-tool-util-ts#114): a format2 step may carry a
+ * raw native `tool_state` block (inline RuntimeValue/ConnectedValue markers,
+ * double-encoded scalars) instead of a schema-aware `state` block. Such a block
+ * must validate against the NATIVE model, not the format2 model — otherwise
+ * inline markers and double-encoded scalars are false-positive failures.
+ *
+ * Schema-aware `state` blocks must still validate against the format2 model.
+ */
+import { ToolStateDiagnostic, validateNativeStepState } from "@galaxy-tool-util/schema";
+import { ToolRegistryService } from "@gxwf/server-common/src/languageTypes";
+import "reflect-metadata";
+import { ToolStateValidationService } from "../../src/services/toolStateValidationService";
+import { createFormat2WorkflowDocument } from "../testHelpers";
+
+const TOOL_ID = "cat1";
+
+const TOOL_PARAMS = [
+  {
+    name: "alignment_type",
+    parameter_type: "gx_select",
+    type: "select",
+    label: "Alignment type",
+    help: null,
+    hidden: false,
+    optional: false,
+    multiple: false,
+    is_dynamic: false,
+    argument: null,
+    validators: [],
+    options: [
+      { label: "End-to-end", value: "end_to_end", selected: true },
+      { label: "Local", value: "local", selected: false },
+    ],
+  },
+  {
+    name: "paired_end",
+    parameter_type: "gx_boolean",
+    type: "boolean",
+    label: "Paired end",
+    help: null,
+    hidden: false,
+    optional: false,
+    value: false,
+    truevalue: "true",
+    falsevalue: "false",
+    is_dynamic: false,
+    argument: null,
+  },
+];
+
+// Mock registry whose validateNativeStep delegates to the real native-model
+// validator so this is a faithful end-to-end repro of the routing.
+function makeMockRegistry(toolId: string, params: unknown[]): ToolRegistryService {
+  return {
+    async hasCached(id) {
+      return id === toolId;
+    },
+    async listCached() {
+      return [];
+    },
+    async populateCache() {
+      return { fetched: 0, alreadyCached: 0, failed: [] };
+    },
+    configure() {},
+    async getCacheSize() {
+      return 1;
+    },
+    async getToolParameters(id) {
+      return id === toolId ? params : null;
+    },
+    hasResolutionFailed() {
+      return false;
+    },
+    markResolutionFailed() {},
+    clearResolutionFailed() {},
+    async getToolInfo() {
+      return null;
+    },
+    getToolShedBaseUrl() {
+      return undefined;
+    },
+    async validateNativeStep(id, _version, toolState, inputConnections) {
+      if (id !== toolId) return [];
+      try {
+        validateNativeStepState(params as never, toolState, inputConnections);
+        return [];
+      } catch (e: unknown) {
+        const issues = (e as { issues?: string[] }).issues ?? [String(e)];
+        return issues.map<ToolStateDiagnostic>((message) => ({ path: "", message, severity: "error" }));
+      }
+    },
+  };
+}
+
+describe("format2 native-shaped tool_state validation (gap 2)", () => {
+  let service: ToolStateValidationService;
+
+  beforeAll(() => {
+    service = new ToolStateValidationService(makeMockRegistry(TOOL_ID, TOOL_PARAMS));
+  });
+
+  it("accepts an inline RuntimeValue in a native tool_state block", async () => {
+    const doc = createFormat2WorkflowDocument(
+      "class: GalaxyWorkflow\ninputs: {}\noutputs: {}\nsteps:\n" +
+        `  step1:\n    tool_id: ${TOOL_ID}\n    tool_state:\n      alignment_type:\n        __class__: RuntimeValue\n`
+    );
+    const diagnostics = await service.doValidation(doc);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("accepts a double-encoded boolean scalar in a native tool_state block", async () => {
+    const doc = createFormat2WorkflowDocument(
+      "class: GalaxyWorkflow\ninputs: {}\noutputs: {}\nsteps:\n" +
+        `  step1:\n    tool_id: ${TOOL_ID}\n    tool_state:\n      paired_end: "true"\n`
+    );
+    const diagnostics = await service.doValidation(doc);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("still validates a schema-aware format2 state block against the format2 model", async () => {
+    const doc = createFormat2WorkflowDocument(
+      "class: GalaxyWorkflow\ninputs: {}\noutputs: {}\nsteps:\n" +
+        `  step1:\n    tool_id: ${TOOL_ID}\n    state:\n      alignment_type: bogus\n`
+    );
+    const diagnostics = await service.doValidation(doc);
+    expect(diagnostics.some((d) => d.message.includes("Invalid value 'bogus'"))).toBe(true);
+  });
+});
+
+// A required data param that has no value in tool_state — only an upstream
+// connection can satisfy it. Native .ga output records that as an inline
+// ConnectedValue marker, but in a gxformat2 file the connection lives in the
+// step's `in:` block instead, so the native validator must be told about it.
+const DATA_TOOL_ID = "cat1";
+const DATA_TOOL_PARAMS = [
+  {
+    name: "read1",
+    parameter_type: "gx_data",
+    type: "data",
+    label: "Read 1",
+    help: null,
+    hidden: false,
+    optional: false,
+    multiple: false,
+    extensions: ["fastq"],
+    is_dynamic: false,
+    argument: null,
+  },
+];
+
+describe("format2 native tool_state with a connected required param (gap 3)", () => {
+  let service: ToolStateValidationService;
+
+  beforeAll(() => {
+    service = new ToolStateValidationService(makeMockRegistry(DATA_TOOL_ID, DATA_TOOL_PARAMS));
+  });
+
+  it("does not flag a required param satisfied by an `in:` connection (map shorthand)", async () => {
+    const doc = createFormat2WorkflowDocument(
+      "class: GalaxyWorkflow\ninputs:\n  upstream:\n    type: data\noutputs: {}\nsteps:\n" +
+        `  step1:\n    tool_id: ${DATA_TOOL_ID}\n    tool_state: {}\n    in:\n      read1:\n        source: upstream\n`
+    );
+    const diagnostics = await service.doValidation(doc);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a required param satisfied by an `in:` connection (bare-string shorthand)", async () => {
+    const doc = createFormat2WorkflowDocument(
+      "class: GalaxyWorkflow\ninputs:\n  upstream:\n    type: data\noutputs: {}\nsteps:\n" +
+        `  step1:\n    tool_id: ${DATA_TOOL_ID}\n    tool_state: {}\n    in:\n      read1: upstream\n`
+    );
+    const diagnostics = await service.doValidation(doc);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a required param satisfied by an `in:` connection (explicit list)", async () => {
+    const doc = createFormat2WorkflowDocument(
+      "class: GalaxyWorkflow\ninputs:\n  upstream:\n    type: data\noutputs: {}\nsteps:\n" +
+        `  step1:\n    tool_id: ${DATA_TOOL_ID}\n    tool_state: {}\n    in:\n      - id: read1\n        source: upstream\n`
+    );
+    const diagnostics = await service.doValidation(doc);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a required param that is neither set nor connected", async () => {
+    const doc = createFormat2WorkflowDocument(
+      "class: GalaxyWorkflow\ninputs: {}\noutputs: {}\nsteps:\n" +
+        `  step1:\n    tool_id: ${DATA_TOOL_ID}\n    tool_state: {}\n`
+    );
+    const diagnostics = await service.doValidation(doc);
+    expect(diagnostics.some((d) => d.message.includes("read1"))).toBe(true);
+  });
+});

--- a/server/gx-workflow-ls-format2/tests/integration/format2NativeToolStateValidation.test.ts
+++ b/server/gx-workflow-ls-format2/tests/integration/format2NativeToolStateValidation.test.ts
@@ -1,11 +1,12 @@
 /**
- * gap 2 (mirrors jmchilton/galaxy-tool-util-ts#114): a format2 step may carry a
- * raw native `tool_state` block (inline RuntimeValue/ConnectedValue markers,
- * double-encoded scalars) instead of a schema-aware `state` block. Such a block
- * must validate against the NATIVE model, not the format2 model — otherwise
- * inline markers and double-encoded scalars are false-positive failures.
+ * A format2 step may carry a raw native `tool_state` block (inline
+ * RuntimeValue/ConnectedValue markers, double-encoded scalars) instead of a
+ * schema-aware `state` block. Such a block must validate against the NATIVE
+ * model, not the format2 model — otherwise inline markers and double-encoded
+ * scalars are false-positive failures. Schema-aware `state` blocks must still
+ * validate against the format2 model.
  *
- * Schema-aware `state` blocks must still validate against the format2 model.
+ * See jmchilton/galaxy-tool-util-ts#114.
  */
 import { ToolStateDiagnostic, validateNativeStepState } from "@galaxy-tool-util/schema";
 import { ToolRegistryService } from "@gxwf/server-common/src/languageTypes";
@@ -93,7 +94,7 @@ function makeMockRegistry(toolId: string, params: unknown[]): ToolRegistryServic
   };
 }
 
-describe("format2 native-shaped tool_state validation (gap 2)", () => {
+describe("format2 native-shaped tool_state validation", () => {
   let service: ToolStateValidationService;
 
   beforeAll(() => {

--- a/server/gx-workflow-ls-format2/tests/integration/listFormSteps.test.ts
+++ b/server/gx-workflow-ls-format2/tests/integration/listFormSteps.test.ts
@@ -1,17 +1,11 @@
 /**
- * Regression test for davelopez/galaxy-workflows-vscode#88:
- * "Tool state validation, hover and completion is not working on gxformat2
- *  workflows. The step's tool is not correctly detected when resolving the context."
+ * Regression test for davelopez/galaxy-workflows-vscode#88.
  *
  * gxformat2 allows `steps:` as either a MAP (keyed by label) or a LIST (array of
  * step objects with a `label`) — see test-data/yaml/validation/test_wf_05.gxwf.yml.
- * Tool-state services resolve a step's tool via getStepNodes() /
- * getStringPropertyFromStep(); both originally only walked object-valued `steps`,
- * and getPathFromNode dropped the falsy array index 0, so the first LIST-form
- * step (and thus its tool_id) was never found — validation, hover, and completion
- * all silently did nothing.
- *
- * MAP-form assertions are controls; LIST-form assertions guard the fix.
+ * These assertions verify tool-state validation, hover, and completion resolve a
+ * step's tool for LIST-form steps, including the step at index 0. MAP-form
+ * assertions are controls; LIST-form assertions guard the fix.
  */
 import { GalaxyWorkflowSchema } from "@galaxy-tool-util/schema";
 import { Hover, ToolRegistryService } from "@gxwf/server-common/src/languageTypes";

--- a/server/gx-workflow-ls-format2/tests/integration/listFormSteps.test.ts
+++ b/server/gx-workflow-ls-format2/tests/integration/listFormSteps.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Regression test for davelopez/galaxy-workflows-vscode#88:
+ * "Tool state validation, hover and completion is not working on gxformat2
+ *  workflows. The step's tool is not correctly detected when resolving the context."
+ *
+ * gxformat2 allows `steps:` as either a MAP (keyed by label) or a LIST (array of
+ * step objects with a `label`) — see test-data/yaml/validation/test_wf_05.gxwf.yml.
+ * Tool-state services resolve a step's tool via getStepNodes() /
+ * getStringPropertyFromStep(); both originally only walked object-valued `steps`,
+ * and getPathFromNode dropped the falsy array index 0, so the first LIST-form
+ * step (and thus its tool_id) was never found — validation, hover, and completion
+ * all silently did nothing.
+ *
+ * MAP-form assertions are controls; LIST-form assertions guard the fix.
+ */
+import { GalaxyWorkflowSchema } from "@galaxy-tool-util/schema";
+import { Hover, ToolRegistryService } from "@gxwf/server-common/src/languageTypes";
+import { parseTemplate } from "@gxwf/server-common/tests/testHelpers";
+import { JSONSchema } from "effect";
+import "reflect-metadata";
+import { JsonSchemaGalaxyWorkflowLoader } from "../../src/schema/jsonSchemaLoader";
+import { GxFormat2CompletionService } from "../../src/services/completionService";
+import { GxFormat2HoverService } from "../../src/services/hoverService";
+import { ToolStateValidationService } from "../../src/services/toolStateValidationService";
+import { createFormat2WorkflowDocument } from "../testHelpers";
+
+const TOOL_ID = "cat1";
+
+const TOOL_PARAMS = [
+  {
+    name: "alignment_type",
+    parameter_type: "gx_select",
+    type: "select",
+    label: "Alignment type",
+    help: null,
+    hidden: false,
+    optional: false,
+    multiple: false,
+    is_dynamic: false,
+    argument: null,
+    validators: [],
+    options: [
+      { label: "End-to-end", value: "end_to_end", selected: true },
+      { label: "Local", value: "local", selected: false },
+    ],
+  },
+];
+
+function makeMockRegistry(toolId: string, params: unknown[]): ToolRegistryService {
+  return {
+    async hasCached(id) {
+      return id === toolId;
+    },
+    async listCached() {
+      return [];
+    },
+    async populateCache() {
+      return { fetched: 0, alreadyCached: 0, failed: [] };
+    },
+    configure() {},
+    async getCacheSize() {
+      return 1;
+    },
+    async getToolParameters(id) {
+      return id === toolId ? params : null;
+    },
+    hasResolutionFailed() {
+      return false;
+    },
+    markResolutionFailed() {},
+    clearResolutionFailed() {},
+    async getToolInfo() {
+      return null;
+    },
+    getToolShedBaseUrl() {
+      return undefined;
+    },
+    async validateNativeStep() {
+      return [];
+    },
+  };
+}
+
+const galaxyWorkflowJsonSchema = JSONSchema.make(GalaxyWorkflowSchema) as Record<string, unknown>;
+
+describe("issue #88: list-form gxformat2 steps tool detection", () => {
+  let validation: ToolStateValidationService;
+  let hover: GxFormat2HoverService;
+  let completion: GxFormat2CompletionService;
+
+  beforeAll(() => {
+    const registry = makeMockRegistry(TOOL_ID, TOOL_PARAMS);
+    validation = new ToolStateValidationService(registry);
+    const schemaNodeResolver = new JsonSchemaGalaxyWorkflowLoader(galaxyWorkflowJsonSchema).nodeResolver;
+    hover = new GxFormat2HoverService(schemaNodeResolver, registry);
+    completion = new GxFormat2CompletionService(schemaNodeResolver, registry);
+  });
+
+  // -------------------------------------------------------------------------
+  // Validation
+  // -------------------------------------------------------------------------
+
+  it("MAP form: validates tool_state (control)", async () => {
+    const doc = createFormat2WorkflowDocument(
+      "class: GalaxyWorkflow\ninputs: {}\noutputs: {}\nsteps:\n" +
+        `  first_cat:\n    tool_id: ${TOOL_ID}\n    state:\n      alignment_type: bogus\n`
+    );
+    const diagnostics = await validation.doValidation(doc);
+    expect(diagnostics.some((d) => d.message.includes("Invalid value 'bogus'"))).toBe(true);
+  });
+
+  it("LIST form: validates tool_state", async () => {
+    const doc = createFormat2WorkflowDocument(
+      "class: GalaxyWorkflow\ninputs: {}\noutputs: {}\nsteps:\n" +
+        `  - tool_id: ${TOOL_ID}\n    label: first_cat\n    state:\n      alignment_type: bogus\n`
+    );
+    const diagnostics = await validation.doValidation(doc);
+    expect(diagnostics.some((d) => d.message.includes("Invalid value 'bogus'"))).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Hover
+  // -------------------------------------------------------------------------
+
+  async function getHover(contents: string, position: { line: number; character: number }): Promise<Hover | null> {
+    return hover.doHover(createFormat2WorkflowDocument(contents), position);
+  }
+
+  it("MAP form: hovers over a tool_state param (control)", async () => {
+    const template =
+      "class: GalaxyWorkflow\ninputs: {}\noutputs: {}\nsteps:\n" +
+      `  first_cat:\n    tool_id: ${TOOL_ID}\n    state:\n      align$ment_type: local`;
+    const { contents, position } = parseTemplate(template);
+    const result = await getHover(contents, position);
+    expect(result).not.toBeNull();
+    const text = typeof result?.contents === "string" ? result.contents : (result?.contents as { value: string }).value;
+    expect(text).toContain("end_to_end");
+  });
+
+  it("LIST form: hovers over a tool_state param", async () => {
+    const template =
+      "class: GalaxyWorkflow\ninputs: {}\noutputs: {}\nsteps:\n" +
+      `  - tool_id: ${TOOL_ID}\n    label: first_cat\n    state:\n      align$ment_type: local`;
+    const { contents, position } = parseTemplate(template);
+    const result = await getHover(contents, position);
+    expect(result).not.toBeNull();
+    const text = typeof result?.contents === "string" ? result.contents : (result?.contents as { value: string }).value;
+    expect(text).toContain("end_to_end");
+  });
+
+  // -------------------------------------------------------------------------
+  // Completion
+  // -------------------------------------------------------------------------
+
+  it("MAP form: completes tool_state param names (control)", async () => {
+    const template =
+      "class: GalaxyWorkflow\ninputs: {}\noutputs: {}\nsteps:\n" +
+      `  first_cat:\n    tool_id: ${TOOL_ID}\n    state:\n      ali$`;
+    const { contents, position } = parseTemplate(template);
+    const result = await completion.doComplete(createFormat2WorkflowDocument(contents), position);
+    expect(result.items.map((i) => i.label)).toContain("alignment_type");
+  });
+
+  it("LIST form: completes tool_state param names", async () => {
+    const template =
+      "class: GalaxyWorkflow\ninputs: {}\noutputs: {}\nsteps:\n" +
+      `  - tool_id: ${TOOL_ID}\n    label: first_cat\n    state:\n      ali$`;
+    const { contents, position } = parseTemplate(template);
+    const result = await completion.doComplete(createFormat2WorkflowDocument(contents), position);
+    expect(result.items.map((i) => i.label)).toContain("alignment_type");
+  });
+});

--- a/server/gx-workflow-ls-format2/tests/integration/toolStateValidation.test.ts
+++ b/server/gx-workflow-ls-format2/tests/integration/toolStateValidation.test.ts
@@ -324,15 +324,15 @@ describe("ToolStateValidationService", () => {
   // ---------------------------------------------------------------------------
 
   it("emits an error diagnostic (not a crash) when a section param has a string value", async () => {
-    // `advanced` is a gx_section: a scalar there makes the schema walker throw.
-    // The service must surface it as a diagnostic, not let the throw escape.
+    // `advanced` is a gx_section: a scalar there is rejected by the schema-aware
+    // validator, which returns a located diagnostic rather than throwing.
     const doc = createFormat2WorkflowDocument(STEP_PREFIX + "      advanced: not_a_dict\n");
     const diagnostics = await service.doValidation(doc);
 
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].severity).toBe(1); // DiagnosticSeverity.Error = 1
     expect(diagnostics[0].message).toBe(
-      "Invalid value for 'advanced': expected a nested object or list, not a plain value."
+      'Invalid value for "advanced": expected a nested object or list, not a plain value.'
     );
   });
 

--- a/server/gx-workflow-ls-format2/tests/integration/toolStateValidation.test.ts
+++ b/server/gx-workflow-ls-format2/tests/integration/toolStateValidation.test.ts
@@ -320,6 +320,23 @@ describe("ToolStateValidationService", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Malformed container state (string where dict/list expected)
+  // ---------------------------------------------------------------------------
+
+  it("emits an error diagnostic (not a crash) when a section param has a string value", async () => {
+    // `advanced` is a gx_section: a scalar there makes the schema walker throw.
+    // The service must surface it as a diagnostic, not let the throw escape.
+    const doc = createFormat2WorkflowDocument(STEP_PREFIX + "      advanced: not_a_dict\n");
+    const diagnostics = await service.doValidation(doc);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].severity).toBe(1); // DiagnosticSeverity.Error = 1
+    expect(diagnostics[0].message).toBe(
+      "Invalid value for 'advanced': expected a nested object or list, not a plain value."
+    );
+  });
+
+  // ---------------------------------------------------------------------------
   // Multiple steps
   // ---------------------------------------------------------------------------
 

--- a/server/gx-workflow-ls-format2/tests/integration/workflowSourceCompletion.test.ts
+++ b/server/gx-workflow-ls-format2/tests/integration/workflowSourceCompletion.test.ts
@@ -291,6 +291,72 @@ steps:
   });
 
   // ---------------------------------------------------------------------------
+  // List-form steps  (steps: [ {label: ..., ...} ])
+  // ---------------------------------------------------------------------------
+
+  it("suggests upstream step outputs when steps are a LIST", async () => {
+    const workflow = `\
+class: GalaxyWorkflow
+inputs:
+  input_data:
+    type: data
+steps:
+  - label: first_step
+    tool_id: cat1
+    in: {}
+    out:
+      - out_file1
+      - out_file2
+    state: {}
+  - label: second_step
+    tool_id: cat1
+    in:
+      - id: query
+        source: $
+    state: {}
+`;
+    const { contents, position } = parseTemplate(workflow);
+
+    const completions = await getCompletions(contents, position);
+    const labels = getCompletionItemsLabels(completions);
+
+    expect(labels).toContain("input_data");
+    expect(labels).toContain("first_step/out_file1");
+    expect(labels).toContain("first_step/out_file2");
+  });
+
+  it("does not suggest forward references when steps are a LIST", async () => {
+    // second_step comes BEFORE first_step in list order — first_step must not appear.
+    const workflow = `\
+class: GalaxyWorkflow
+inputs:
+  input_data:
+    type: data
+steps:
+  - label: second_step
+    tool_id: cat1
+    in:
+      - id: query
+        source: $
+    out: []
+    state: {}
+  - label: first_step
+    tool_id: cat1
+    in: {}
+    out:
+      - out_file1
+    state: {}
+`;
+    const { contents, position } = parseTemplate(workflow);
+
+    const completions = await getCompletions(contents, position);
+    const labels = getCompletionItemsLabels(completions);
+
+    expect(labels).toContain("input_data");
+    expect(labels).not.toContain("first_step/out_file1");
+  });
+
+  // ---------------------------------------------------------------------------
   // No upstream steps / no inputs
   // ---------------------------------------------------------------------------
 

--- a/server/gx-workflow-ls-native/package.json
+++ b/server/gx-workflow-ls-native/package.json
@@ -5,8 +5,8 @@
   "author": "davelopez",
   "license": "MIT",
   "dependencies": {
-    "@galaxy-tool-util/core": "^1.8.0",
-    "@galaxy-tool-util/schema": "^1.8.0",
+    "@galaxy-tool-util/core": "^1.8.2",
+    "@galaxy-tool-util/schema": "^1.8.2",
     "@gxwf/server-common": "workspace:*",
     "@gxwf/workflow-tests-language-service": "workspace:*",
     "@gxwf/yaml-language-service": "workspace:*",

--- a/server/gx-workflow-ls-native/package.json
+++ b/server/gx-workflow-ls-native/package.json
@@ -5,8 +5,8 @@
   "author": "davelopez",
   "license": "MIT",
   "dependencies": {
-    "@galaxy-tool-util/core": "^1.8.2",
-    "@galaxy-tool-util/schema": "^1.8.2",
+    "@galaxy-tool-util/core": "^1.9.0",
+    "@galaxy-tool-util/schema": "^1.9.0",
     "@gxwf/server-common": "workspace:*",
     "@gxwf/workflow-tests-language-service": "workspace:*",
     "@gxwf/yaml-language-service": "workspace:*",

--- a/server/gx-workflow-ls-native/package.json
+++ b/server/gx-workflow-ls-native/package.json
@@ -5,8 +5,8 @@
   "author": "davelopez",
   "license": "MIT",
   "dependencies": {
-    "@galaxy-tool-util/core": "^1.1.0",
-    "@galaxy-tool-util/schema": "^1.1.0",
+    "@galaxy-tool-util/core": "^1.8.0",
+    "@galaxy-tool-util/schema": "^1.8.0",
     "@gxwf/server-common": "workspace:*",
     "@gxwf/workflow-tests-language-service": "workspace:*",
     "@gxwf/yaml-language-service": "workspace:*",

--- a/server/gx-workflow-ls-native/src/services/nativeToolStateValidationService.ts
+++ b/server/gx-workflow-ls-native/src/services/nativeToolStateValidationService.ts
@@ -103,7 +103,27 @@ export class NativeToolStateValidationService {
       toolStateParsed,
       inputConnections,
     } of collectNativeStepsWithStringState(nodeManager)) {
-      if (!(await this.toolRegistryService.hasCached(toolId, toolVersion))) {
+      // Flat resolver: all diagnostics for a string-encoded tool_state point at the whole string.
+      const stringRange = nodeManager.getNodeRange(toolStateStringNode);
+
+      if (await this.toolRegistryService.hasCached(toolId, toolVersion)) {
+        let rawDiags: ToolStateDiagnostic[] = [];
+        try {
+          rawDiags = await this.toolRegistryService.validateNativeStep(
+            toolId,
+            toolVersion,
+            toolStateParsed,
+            inputConnections
+          );
+        } catch {
+          rawDiags = [];
+        }
+        const passBDiags = mapToolStateDiagnosticsToLSP(rawDiags, () => stringRange).map((d) => ({
+          ...d,
+          code: LEGACY_TOOL_STATE_CODE,
+        }));
+        result.push(...passBDiags);
+      } else {
         result.push(
           buildCacheMissDiagnostic(
             toolId,
@@ -111,29 +131,11 @@ export class NativeToolStateValidationService {
             nodeManager.getNodeRange(toolIdNode)
           )
         );
-        continue;
       }
 
-      let rawDiags: ToolStateDiagnostic[] = [];
-      try {
-        rawDiags = await this.toolRegistryService.validateNativeStep(
-          toolId,
-          toolVersion,
-          toolStateParsed,
-          inputConnections
-        );
-      } catch {
-        rawDiags = [];
-      }
-      // Flat resolver: all diagnostics for a string-encoded tool_state point at the whole string.
-      const stringRange = nodeManager.getNodeRange(toolStateStringNode);
-      const passBDiags = mapToolStateDiagnosticsToLSP(rawDiags, () => stringRange).map((d) => ({
-        ...d,
-        code: LEGACY_TOOL_STATE_CODE,
-      }));
-      result.push(...passBDiags);
-      // Always emit a hint so the "Clean workflow" quick fix is discoverable even when
-      // there are no param validation errors.
+      // The string encoding alone marks this state as legacy; the "Clean workflow" quick
+      // fix re-encodes it to object form without needing the tool, so emit the hint
+      // regardless of cache status or param validation outcome.
       result.push(buildLegacyToolStateHintDiagnostic(stringRange));
     }
 

--- a/server/gx-workflow-ls-native/tests/integration/nativeToolStateValidation.test.ts
+++ b/server/gx-workflow-ls-native/tests/integration/nativeToolStateValidation.test.ts
@@ -188,24 +188,25 @@ describe("NativeToolStateValidationService integration — object tool_state (Pa
     expect(diags.some((d) => d.severity === 2 && d.message.includes("unknown_key"))).toBe(true);
   });
 
-  it("surfaces a validator throw as a diagnostic instead of crashing", async () => {
-    // Mirrors the schema walker throwing on a scalar-valued container param.
-    const throwingRegistry = makeMockRegistry();
-    throwingRegistry.validateNativeStep = async () => {
-      throw new Error(
-        'Container parameter "advanced" (gx_section) has string value — expected dict/list. ' +
-          "This indicates legacy parameter encoding which is not supported. Decode the workflow first."
-      );
-    };
-    const throwingService = new NativeToolStateValidationService(throwingRegistry);
+  it("surfaces a string-container diagnostic from the validator at the param range", async () => {
+    // The schema-aware validator now returns a located diagnostic (rather than
+    // throwing) when a container param is given a scalar. Verify it maps to an
+    // Error diagnostic pointing at the offending param.
+    const registry = makeMockRegistry();
+    registry.validateNativeStep = async () => [
+      {
+        path: "advanced",
+        message: 'Invalid value for "advanced": expected a nested object or list, not a plain value.',
+        severity: "error",
+      },
+    ];
+    const svc = new NativeToolStateValidationService(registry);
     const doc = createNativeWorkflowDocument(nativeWorkflowWithObjectState({ advanced: "not_a_dict" }));
-    const diags = await throwingService.doValidation(doc);
+    const diags = await svc.doValidation(doc);
 
     expect(diags).toHaveLength(1);
     expect(diags[0].severity).toBe(1); // DiagnosticSeverity.Error
-    expect(diags[0].message).toBe(
-      "Invalid value for 'advanced': expected a nested object or list, not a plain value."
-    );
+    expect(diags[0].message).toBe('Invalid value for "advanced": expected a nested object or list, not a plain value.');
   });
 
   it("emits Information diagnostic for uncached tool", async () => {

--- a/server/gx-workflow-ls-native/tests/integration/nativeToolStateValidation.test.ts
+++ b/server/gx-workflow-ls-native/tests/integration/nativeToolStateValidation.test.ts
@@ -188,6 +188,26 @@ describe("NativeToolStateValidationService integration — object tool_state (Pa
     expect(diags.some((d) => d.severity === 2 && d.message.includes("unknown_key"))).toBe(true);
   });
 
+  it("surfaces a validator throw as a diagnostic instead of crashing", async () => {
+    // Mirrors the schema walker throwing on a scalar-valued container param.
+    const throwingRegistry = makeMockRegistry();
+    throwingRegistry.validateNativeStep = async () => {
+      throw new Error(
+        'Container parameter "advanced" (gx_section) has string value — expected dict/list. ' +
+          "This indicates legacy parameter encoding which is not supported. Decode the workflow first."
+      );
+    };
+    const throwingService = new NativeToolStateValidationService(throwingRegistry);
+    const doc = createNativeWorkflowDocument(nativeWorkflowWithObjectState({ advanced: "not_a_dict" }));
+    const diags = await throwingService.doValidation(doc);
+
+    expect(diags).toHaveLength(1);
+    expect(diags[0].severity).toBe(1); // DiagnosticSeverity.Error
+    expect(diags[0].message).toBe(
+      "Invalid value for 'advanced': expected a nested object or list, not a plain value."
+    );
+  });
+
   it("emits Information diagnostic for uncached tool", async () => {
     const doc = createNativeWorkflowDocument(
       JSON.stringify({

--- a/server/gx-workflow-ls-native/tests/unit/nativeToolStateValidation.test.ts
+++ b/server/gx-workflow-ls-native/tests/unit/nativeToolStateValidation.test.ts
@@ -140,14 +140,20 @@ describe("NativeToolStateValidationService", () => {
     expect(diags[0].message).toContain("Could not resolve tool");
   });
 
-  it("emits Information diagnostic when tool is not cached (string state)", async () => {
+  it("emits Information diagnostic plus legacy hint when tool is not cached (string state)", async () => {
     const service = new NativeToolStateValidationService(makeMockRegistry({ cached: false, resolutionFailed: false }));
     const doc = createNativeWorkflowDocument(makeWorkflowWithStringState({ key: "val" }));
     const diags = await service.doValidation(doc);
 
-    expect(diags).toHaveLength(1);
-    expect(diags[0].severity).toBe(3);
-    expect(diags[0].message).toContain("not in the local cache");
+    // The "Clean workflow" quick fix re-encodes string state without needing the tool,
+    // so the hint is offered even when the tool is uncached.
+    expect(diags).toHaveLength(2);
+    const cacheMiss = diags.find((d) => d.severity === 3); // Information
+    expect(cacheMiss).toBeDefined();
+    expect(cacheMiss!.message).toContain("not in the local cache");
+    const hint = diags.find((d) => d.severity === 4); // Hint
+    expect(hint).toBeDefined();
+    expect(hint!.code).toBe("legacy-tool-state");
   });
 
   // --- Object state: valid / invalid ---

--- a/server/packages/server-common/package.json
+++ b/server/packages/server-common/package.json
@@ -6,9 +6,9 @@
   "license": "MIT",
   "type": "module",
   "dependencies": {
-    "@galaxy-tool-util/core": "^1.8.2",
-    "@galaxy-tool-util/schema": "^1.8.2",
-    "@galaxy-tool-util/search": "^1.8.2",
+    "@galaxy-tool-util/core": "^1.9.0",
+    "@galaxy-tool-util/schema": "^1.9.0",
+    "@galaxy-tool-util/search": "^1.9.0",
     "@types/node": "^20.5.7",
     "inversify": "^6.0.2",
     "reflect-metadata": "^0.2.2",

--- a/server/packages/server-common/package.json
+++ b/server/packages/server-common/package.json
@@ -6,9 +6,9 @@
   "license": "MIT",
   "type": "module",
   "dependencies": {
-    "@galaxy-tool-util/core": "^1.8.0",
-    "@galaxy-tool-util/schema": "^1.8.0",
-    "@galaxy-tool-util/search": "^1.8.0",
+    "@galaxy-tool-util/core": "^1.8.2",
+    "@galaxy-tool-util/schema": "^1.8.2",
+    "@galaxy-tool-util/search": "^1.8.2",
     "@types/node": "^20.5.7",
     "inversify": "^6.0.2",
     "reflect-metadata": "^0.2.2",

--- a/server/packages/server-common/package.json
+++ b/server/packages/server-common/package.json
@@ -6,9 +6,9 @@
   "license": "MIT",
   "type": "module",
   "dependencies": {
-    "@galaxy-tool-util/core": "^1.1.0",
-    "@galaxy-tool-util/schema": "^1.1.0",
-    "@galaxy-tool-util/search": "^1.1.0",
+    "@galaxy-tool-util/core": "^1.8.0",
+    "@galaxy-tool-util/schema": "^1.8.0",
+    "@galaxy-tool-util/search": "^1.8.0",
     "@types/node": "^20.5.7",
     "inversify": "^6.0.2",
     "reflect-metadata": "^0.2.2",

--- a/server/packages/server-common/src/ast/nodeManager.ts
+++ b/server/packages/server-common/src/ast/nodeManager.ts
@@ -122,7 +122,8 @@ export class ASTNodeManager {
     let current = node;
     while (current) {
       const segment = this.getNodeSegment(current);
-      if (segment) {
+      // Note: `segment` can be the numeric array index 0, which is falsy — guard against undefined explicitly.
+      if (segment !== undefined) {
         path.push(segment);
       }
       current = current.parent;
@@ -157,9 +158,20 @@ export class ASTNodeManager {
       stepsPropertyNodes = mainStepsProperty ? [mainStepsProperty] : [];
     }
     for (const stepsNode of stepsPropertyNodes) {
-      if (stepsNode && stepsNode.valueNode && stepsNode.valueNode.type === "object") {
-        stepsNode.valueNode.properties.forEach((stepProperty) => {
+      const stepsValue = stepsNode?.valueNode;
+      if (!stepsValue) {
+        continue;
+      }
+      // gxformat2 allows `steps` as a map (keyed by label) or a list (array of step objects).
+      if (stepsValue.type === "object") {
+        stepsValue.properties.forEach((stepProperty) => {
           const stepNode = stepProperty.valueNode;
+          if (stepNode && stepNode.type === "object") {
+            result.push(stepNode);
+          }
+        });
+      } else if (stepsValue.type === "array") {
+        stepsValue.items.forEach((stepNode) => {
           if (stepNode && stepNode.type === "object") {
             result.push(stepNode);
           }

--- a/server/packages/server-common/src/ast/utils.ts
+++ b/server/packages/server-common/src/ast/utils.ts
@@ -7,6 +7,34 @@ export function getPathSegments(path: string): string[] | null {
   return segments;
 }
 
+/**
+ * Convert an AST node into the plain JS value it represents, discarding
+ * position information. Mirrors the structure jsonc/YAML parsers produce, so
+ * the result can be fed to value-based helpers (e.g. the gxformat2 step
+ * shorthand normalizers) that have no AST awareness.
+ */
+export function getNodeValue(node: ASTNode): unknown {
+  switch (node.type) {
+    case "object": {
+      const obj: Record<string, unknown> = {};
+      for (const prop of node.properties) {
+        if (prop.valueNode) obj[String(prop.keyNode.value)] = getNodeValue(prop.valueNode);
+      }
+      return obj;
+    }
+    case "array":
+      return node.items.map(getNodeValue);
+    case "string":
+    case "number":
+    case "boolean":
+      return node.value;
+    case "null":
+      return null;
+    default:
+      return undefined;
+  }
+}
+
 export function getPropertyNodeFromPath(root: ASTNode, path: string): ASTNode | null {
   let segments = getPathSegments(path);
   if (!segments) return null;

--- a/server/packages/server-common/src/providers/validation/toolStateAstHelpers.ts
+++ b/server/packages/server-common/src/providers/validation/toolStateAstHelpers.ts
@@ -20,6 +20,8 @@ export interface StepWithToolState {
   toolVersion?: string;
   /** The string-valued tool_id AST node — used for "not cached" diagnostics. */
   toolIdNode: ASTNode;
+  /** Which key the state came from: schema-aware `state` vs raw native `tool_state`. */
+  stateKey: "state" | "tool_state";
   /** The object-valued tool_state/state node. */
   stateValueNode: ObjectASTNode;
   /** The containing step object node (for sibling properties like input_connections). */
@@ -51,6 +53,7 @@ export function collectStepsWithObjectState(nodeManager: ASTNodeManager): StepWi
       toolId,
       toolVersion,
       toolIdNode: toolIdProp.valueNode,
+      stateKey: stateProp.keyNode.value as "state" | "tool_state",
       stateValueNode: stateProp.valueNode as ObjectASTNode,
       stepNode,
     });
@@ -173,6 +176,27 @@ export function dotPathToAstRange(
 // ---------------------------------------------------------------------------
 
 /**
+ * Walk the AST from `root` along `stepPath` segments. Segments are object
+ * property names or numeric array indices, so this resolves steps whether
+ * gxformat2 `steps` is a map (e.g. `[steps, my_step]`) or a list (`[steps, 0]`).
+ */
+function navigateStepPath(root: ASTNode | undefined, stepPath: NodePath): ASTNode | undefined {
+  let current: ASTNode | undefined = root;
+  for (const seg of stepPath) {
+    if (!current) return undefined;
+    if (typeof seg === "number") {
+      if (current.type !== "array") return undefined;
+      current = (current as ArrayASTNode).items[seg];
+    } else {
+      if (current.type !== "object") return undefined;
+      const prop = (current as ObjectASTNode).properties.find((p) => p.keyNode.value === seg);
+      current = prop?.valueNode;
+    }
+  }
+  return current;
+}
+
+/**
  * Navigate the AST from root along `stepPath` segments and return the string
  * value of `propertyName` on the resulting step object, or undefined.
  */
@@ -181,12 +205,7 @@ export function getStringPropertyFromStep(
   stepPath: NodePath,
   propertyName: string
 ): string | undefined {
-  let current: ASTNode | undefined = root;
-  for (const seg of stepPath) {
-    if (!current || current.type !== "object") return undefined;
-    const prop = (current as ObjectASTNode).properties.find((p) => p.keyNode.value === seg);
-    current = prop?.valueNode;
-  }
+  const current = navigateStepPath(root, stepPath);
   if (!current || current.type !== "object") return undefined;
   const prop = (current as ObjectASTNode).properties.find((p) => p.keyNode.value === propertyName);
   const val = prop?.valueNode;
@@ -203,12 +222,7 @@ export function getObjectNodeFromStep(
   stepPath: NodePath,
   propertyName: string
 ): ObjectASTNode | undefined {
-  let current: ASTNode | undefined = root;
-  for (const seg of stepPath) {
-    if (!current || current.type !== "object") return undefined;
-    const prop = (current as ObjectASTNode).properties.find((p) => p.keyNode.value === seg);
-    current = prop?.valueNode;
-  }
+  const current = navigateStepPath(root, stepPath);
   if (!current || current.type !== "object") return undefined;
   const prop = (current as ObjectASTNode).properties.find((p) => p.keyNode.value === propertyName);
   const val = prop?.valueNode;

--- a/server/packages/server-common/src/providers/validation/toolStateDiagnostics.ts
+++ b/server/packages/server-common/src/providers/validation/toolStateDiagnostics.ts
@@ -36,6 +36,45 @@ export function buildCacheMissDiagnostic(toolId: string, hasFailed: boolean, ran
   };
 }
 
+// Matches the schema walker's "container got a scalar" error so we can render a
+// concise, format-agnostic message instead of the raw native-decode jargon.
+const STRING_CONTAINER_RE = /Container parameter "([^"]+)" \([^)]+\) has string value/;
+
+/**
+ * Extract the offending parameter name from a schema-walker container error,
+ * or undefined for any other error. Lets callers resolve a precise AST range.
+ */
+export function paramNameFromContainerError(error: unknown): string | undefined {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.match(STRING_CONTAINER_RE)?.[1];
+}
+
+/**
+ * Turn an error thrown by the format-specific tool-state validator into a
+ * Diagnostic instead of letting it crash the whole validation pass.
+ *
+ * The schema walker throws a plain Error when a container parameter
+ * (section/repeat/conditional) is given a scalar value. We surface that as a
+ * targeted Error diagnostic; any other unexpected error becomes a generic one
+ * so it is still reported rather than silently dropped.
+ */
+export function buildToolStateErrorDiagnostic(error: unknown, range: Range): Diagnostic {
+  const message = error instanceof Error ? error.message : String(error);
+  const paramName = paramNameFromContainerError(error);
+  if (paramName) {
+    return {
+      message: `Invalid value for '${paramName}': expected a nested object or list, not a plain value.`,
+      range,
+      severity: DiagnosticSeverity.Error,
+    };
+  }
+  return {
+    message: `Tool state could not be validated: ${message}`,
+    range,
+    severity: DiagnosticSeverity.Error,
+  };
+}
+
 /**
  * Convert ToolStateDiagnostic[] to LSP Diagnostic[].
  *

--- a/server/packages/server-common/src/providers/validation/toolStateDiagnostics.ts
+++ b/server/packages/server-common/src/providers/validation/toolStateDiagnostics.ts
@@ -36,45 +36,6 @@ export function buildCacheMissDiagnostic(toolId: string, hasFailed: boolean, ran
   };
 }
 
-// Matches the schema walker's "container got a scalar" error so we can render a
-// concise, format-agnostic message instead of the raw native-decode jargon.
-const STRING_CONTAINER_RE = /Container parameter "([^"]+)" \([^)]+\) has string value/;
-
-/**
- * Extract the offending parameter name from a schema-walker container error,
- * or undefined for any other error. Lets callers resolve a precise AST range.
- */
-export function paramNameFromContainerError(error: unknown): string | undefined {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.match(STRING_CONTAINER_RE)?.[1];
-}
-
-/**
- * Turn an error thrown by the format-specific tool-state validator into a
- * Diagnostic instead of letting it crash the whole validation pass.
- *
- * The schema walker throws a plain Error when a container parameter
- * (section/repeat/conditional) is given a scalar value. We surface that as a
- * targeted Error diagnostic; any other unexpected error becomes a generic one
- * so it is still reported rather than silently dropped.
- */
-export function buildToolStateErrorDiagnostic(error: unknown, range: Range): Diagnostic {
-  const message = error instanceof Error ? error.message : String(error);
-  const paramName = paramNameFromContainerError(error);
-  if (paramName) {
-    return {
-      message: `Invalid value for '${paramName}': expected a nested object or list, not a plain value.`,
-      range,
-      severity: DiagnosticSeverity.Error,
-    };
-  }
-  return {
-    message: `Tool state could not be validated: ${message}`,
-    range,
-    severity: DiagnosticSeverity.Error,
-  };
-}
-
 /**
  * Convert ToolStateDiagnostic[] to LSP Diagnostic[].
  *

--- a/server/packages/server-common/src/providers/validation/toolStateValidation.ts
+++ b/server/packages/server-common/src/providers/validation/toolStateValidation.ts
@@ -14,14 +14,17 @@ import { buildCacheMissDiagnostic, mapToolStateDiagnosticsToLSP } from "./toolSt
 
 /**
  * Format-specific validation for a single step. Receives the tool ID, version,
- * object-valued state node, and the parent step node (for siblings such as
- * `input_connections`). Returns raw ToolStateDiagnostics.
+ * object-valued state node, the parent step node (for siblings such as
+ * `input_connections`), and which key the state came from (`state` vs
+ * `tool_state`) so callers can pick a validator by state shape. Returns raw
+ * ToolStateDiagnostics.
  */
 export type StepStateValidator = (
   toolId: string,
   toolVersion: string | undefined,
   stateValueNode: ObjectASTNode,
-  stepNode: ObjectASTNode
+  stepNode: ObjectASTNode,
+  stateKey: "state" | "tool_state"
 ) => Promise<ToolStateDiagnostic[]>;
 
 /**
@@ -39,7 +42,7 @@ export async function runObjectStateValidationLoop(
 ): Promise<Diagnostic[]> {
   const result: Diagnostic[] = [];
 
-  for (const { toolId, toolVersion, toolIdNode, stateValueNode, stepNode } of collectStepsWithObjectState(
+  for (const { toolId, toolVersion, toolIdNode, stateKey, stateValueNode, stepNode } of collectStepsWithObjectState(
     nodeManager
   )) {
     if (!(await registry.hasCached(toolId, toolVersion))) {
@@ -53,7 +56,7 @@ export async function runObjectStateValidationLoop(
       continue;
     }
 
-    const rawDiags = await validator(toolId, toolVersion, stateValueNode, stepNode);
+    const rawDiags = await validator(toolId, toolVersion, stateValueNode, stepNode, stateKey);
     const resolver = (path: string, target: "key" | "value"): Range | undefined =>
       dotPathToAstRange(stateValueNode, path, nodeManager, target);
     result.push(...mapToolStateDiagnosticsToLSP(rawDiags, resolver));

--- a/server/packages/server-common/src/providers/validation/toolStateValidation.ts
+++ b/server/packages/server-common/src/providers/validation/toolStateValidation.ts
@@ -10,12 +10,7 @@ import type { ObjectASTNode } from "../../ast/types";
 import { ASTNodeManager } from "../../ast/nodeManager";
 import { Diagnostic, Range } from "vscode-languageserver-types";
 import { collectStepsWithObjectState, dotPathToAstRange } from "./toolStateAstHelpers";
-import {
-  buildCacheMissDiagnostic,
-  buildToolStateErrorDiagnostic,
-  mapToolStateDiagnosticsToLSP,
-  paramNameFromContainerError,
-} from "./toolStateDiagnostics";
+import { buildCacheMissDiagnostic, mapToolStateDiagnosticsToLSP } from "./toolStateDiagnostics";
 
 /**
  * Format-specific validation for a single step. Receives the tool ID, version,
@@ -61,22 +56,7 @@ export async function runObjectStateValidationLoop(
       continue;
     }
 
-    // The format-specific validator (and the schema walker it drives) throws on
-    // malformed state — e.g. a scalar where a container is expected. Convert that
-    // into a diagnostic so one bad step doesn't crash validation for the rest.
-    let rawDiags: ToolStateDiagnostic[];
-    try {
-      rawDiags = await validator(toolId, toolVersion, stateValueNode, stepNode, stateKey);
-    } catch (error) {
-      // Point at the offending param when the error names one (the walker's
-      // container errors do); otherwise highlight the whole state block.
-      const paramName = paramNameFromContainerError(error);
-      const range = paramName
-        ? dotPathToAstRange(stateValueNode, paramName, nodeManager, "value")
-        : nodeManager.getNodeRange(stateValueNode);
-      result.push(buildToolStateErrorDiagnostic(error, range));
-      continue;
-    }
+    const rawDiags = await validator(toolId, toolVersion, stateValueNode, stepNode, stateKey);
     const resolver = (path: string, target: "key" | "value"): Range | undefined =>
       dotPathToAstRange(stateValueNode, path, nodeManager, target);
     result.push(...mapToolStateDiagnosticsToLSP(rawDiags, resolver));

--- a/server/packages/server-common/src/providers/validation/toolStateValidation.ts
+++ b/server/packages/server-common/src/providers/validation/toolStateValidation.ts
@@ -10,7 +10,12 @@ import type { ObjectASTNode } from "../../ast/types";
 import { ASTNodeManager } from "../../ast/nodeManager";
 import { Diagnostic, Range } from "vscode-languageserver-types";
 import { collectStepsWithObjectState, dotPathToAstRange } from "./toolStateAstHelpers";
-import { buildCacheMissDiagnostic, mapToolStateDiagnosticsToLSP } from "./toolStateDiagnostics";
+import {
+  buildCacheMissDiagnostic,
+  buildToolStateErrorDiagnostic,
+  mapToolStateDiagnosticsToLSP,
+  paramNameFromContainerError,
+} from "./toolStateDiagnostics";
 
 /**
  * Format-specific validation for a single step. Receives the tool ID, version,
@@ -56,7 +61,22 @@ export async function runObjectStateValidationLoop(
       continue;
     }
 
-    const rawDiags = await validator(toolId, toolVersion, stateValueNode, stepNode, stateKey);
+    // The format-specific validator (and the schema walker it drives) throws on
+    // malformed state — e.g. a scalar where a container is expected. Convert that
+    // into a diagnostic so one bad step doesn't crash validation for the rest.
+    let rawDiags: ToolStateDiagnostic[];
+    try {
+      rawDiags = await validator(toolId, toolVersion, stateValueNode, stepNode, stateKey);
+    } catch (error) {
+      // Point at the offending param when the error names one (the walker's
+      // container errors do); otherwise highlight the whole state block.
+      const paramName = paramNameFromContainerError(error);
+      const range = paramName
+        ? dotPathToAstRange(stateValueNode, paramName, nodeManager, "value")
+        : nodeManager.getNodeRange(stateValueNode);
+      result.push(buildToolStateErrorDiagnostic(error, range));
+      continue;
+    }
     const resolver = (path: string, target: "key" | "value"): Range | undefined =>
       dotPathToAstRange(stateValueNode, path, nodeManager, target);
     result.push(...mapToolStateDiagnosticsToLSP(rawDiags, resolver));

--- a/server/packages/server-common/src/server.ts
+++ b/server/packages/server-common/src/server.ts
@@ -147,7 +147,11 @@ export class GalaxyWorkflowLanguageServerImpl implements GalaxyWorkflowLanguageS
         docContext = languageService.parseDocument(event.document);
         this.documentsCache.addOrReplaceDocument(docContext);
       }
-      void this.toolCacheService?.scheduleResolution(docContext);
+      // Don't let a rejected resolution vanish silently — auto-resolution
+      // failures here are otherwise invisible (no diagnostic, no log).
+      this.toolCacheService?.scheduleResolution(docContext).catch((error) => {
+        this.connection.console.error(`Tool auto-resolution failed on open: ${String(error)}`);
+      });
     });
   }
 

--- a/server/packages/server-common/src/services/toolCacheService.ts
+++ b/server/packages/server-common/src/services/toolCacheService.ts
@@ -128,6 +128,7 @@ export class ToolCacheService extends ServiceBase {
 
     this.server.connection.onRequest(LSRequestIdentifiers.GET_TOOL_CACHE_STATUS, async () => ({
       cacheSize: await this.server.toolRegistryService.getCacheSize(),
+      autoResolutionEnabled: this.server.autoResolutionEnabled,
     }));
 
     this.server.connection.onRequest(LSRequestIdentifiers.GET_WORKFLOW_TOOLS, (params: GetWorkflowToolsParams) =>

--- a/server/packages/server-common/tests/unit/toolCacheServiceScheduleResolution.test.ts
+++ b/server/packages/server-common/tests/unit/toolCacheServiceScheduleResolution.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from "vitest";
+import { getLanguageService } from "vscode-json-languageservice";
+
+import type {
+  DocumentContext,
+  GalaxyWorkflowLanguageServer,
+  PopulateToolCacheResult,
+  ToolRegistryService,
+} from "../../src/languageTypes";
+import { TextDocument } from "../../src/languageTypes";
+import { WorkflowDocument } from "../../src/models/workflowDocument";
+import { ToolCacheService } from "../../src/services/toolCacheService";
+
+const FASTP = "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/1.1.0+galaxy0";
+const MULTIQC = "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.33+galaxy0";
+
+class TestWorkflowDocument extends WorkflowDocument {
+  public getWorkflowInputs(): never {
+    throw new Error("not used");
+  }
+  public getWorkflowOutputs(): never {
+    throw new Error("not used");
+  }
+}
+
+function createDoc(): DocumentContext {
+  const json = JSON.stringify({
+    a_galaxy_workflow: "true",
+    steps: {
+      "0": { id: 0, type: "data_input", tool_id: null },
+      "1": { id: 1, type: "tool", tool_id: FASTP, tool_version: "1.1.0+galaxy0" },
+      "2": { id: 2, type: "tool", tool_id: MULTIQC, tool_version: "1.33+galaxy0" },
+    },
+  });
+  const textDoc = TextDocument.create("foo://bar/iwc.ga", "json", 0, json);
+  const ls = getLanguageService({});
+  const jsonDoc = ls.parseJSONDocument(textDoc);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new TestWorkflowDocument(textDoc, jsonDoc as any);
+}
+
+function makeRegistry(populateSpy: ReturnType<typeof vi.fn>): ToolRegistryService {
+  return {
+    async hasCached() {
+      return false;
+    },
+    async listCached() {
+      return [];
+    },
+    populateCache: populateSpy,
+    configure() {
+      /* noop */
+    },
+    async getCacheSize() {
+      return 0;
+    },
+    async getToolParameters() {
+      return null;
+    },
+    async getToolInfo() {
+      return null;
+    },
+    getToolShedBaseUrl() {
+      return undefined;
+    },
+    hasResolutionFailed() {
+      return false;
+    },
+    markResolutionFailed() {
+      /* noop */
+    },
+    clearResolutionFailed() {
+      /* noop */
+    },
+    async validateNativeStep() {
+      return [];
+    },
+  } as unknown as ToolRegistryService;
+}
+
+function makeServer(autoResolutionEnabled: boolean, registry: ToolRegistryService): GalaxyWorkflowLanguageServer {
+  return {
+    connection: {
+      onRequest: () => {
+        /* noop */
+      },
+      sendNotification: () => {
+        /* noop */
+      },
+    },
+    toolRegistryService: registry,
+    documentsCache: { get: () => undefined, all: () => [] },
+    autoResolutionEnabled,
+    revalidateDocument: () => {
+      /* noop */
+    },
+  } as unknown as GalaxyWorkflowLanguageServer;
+}
+
+describe("ToolCacheService.scheduleResolution", () => {
+  it("auto-resolves uncached tools after the debounce when enabled", async () => {
+    const populateSpy = vi.fn(
+      async (): Promise<PopulateToolCacheResult> => ({ fetched: 2, alreadyCached: 0, failed: [] })
+    );
+    const service = new ToolCacheService(makeServer(true, makeRegistry(populateSpy)));
+
+    await service.scheduleResolution(createDoc());
+    await new Promise((r) => setTimeout(r, 400));
+
+    expect(populateSpy).toHaveBeenCalledTimes(1);
+    const tools = populateSpy.mock.calls[0][0] as Array<{ toolId: string }>;
+    expect(tools.map((t) => t.toolId).sort()).toEqual([FASTP, MULTIQC].sort());
+  });
+
+  it("does not auto-resolve when disabled", async () => {
+    const populateSpy = vi.fn(
+      async (): Promise<PopulateToolCacheResult> => ({ fetched: 0, alreadyCached: 0, failed: [] })
+    );
+    const service = new ToolCacheService(makeServer(false, makeRegistry(populateSpy)));
+
+    await service.scheduleResolution(createDoc());
+    await new Promise((r) => setTimeout(r, 400));
+
+    expect(populateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/server/packages/server-common/tests/unit/toolStateDiagnostics.test.ts
+++ b/server/packages/server-common/tests/unit/toolStateDiagnostics.test.ts
@@ -2,7 +2,9 @@ import { DiagnosticSeverity, type Range } from "vscode-languageserver-types";
 import type { ToolStateDiagnostic } from "../../src/languageTypes";
 import {
   buildCacheMissDiagnostic,
+  buildToolStateErrorDiagnostic,
   mapToolStateDiagnosticsToLSP,
+  paramNameFromContainerError,
 } from "../../src/providers/validation/toolStateDiagnostics";
 
 const RANGE = { start: { line: 0, character: 0 }, end: { line: 0, character: 10 } };
@@ -27,6 +29,40 @@ describe("buildCacheMissDiagnostic", () => {
     expect(diag.severity).toBe(DiagnosticSeverity.Warning);
     expect(diag.message).toContain("Could not resolve tool");
     expect(diag.message).toContain("my_tool");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildToolStateErrorDiagnostic / paramNameFromContainerError
+// ---------------------------------------------------------------------------
+
+describe("buildToolStateErrorDiagnostic", () => {
+  const WALKER_ERROR = new Error(
+    'Container parameter "advanced" (gx_section) has string value — expected dict/list. ' +
+      "This indicates legacy parameter encoding which is not supported. Decode the workflow first."
+  );
+
+  it("extracts the param name from a walker container error", () => {
+    expect(paramNameFromContainerError(WALKER_ERROR)).toBe("advanced");
+    expect(paramNameFromContainerError(new Error("boom"))).toBeUndefined();
+  });
+
+  it("renders a concise message for a walker container error", () => {
+    const diag = buildToolStateErrorDiagnostic(WALKER_ERROR, RANGE);
+    expect(diag.severity).toBe(DiagnosticSeverity.Error);
+    expect(diag.message).toBe("Invalid value for 'advanced': expected a nested object or list, not a plain value.");
+    expect(diag.message).not.toContain("Decode the workflow"); // native jargon stripped
+    expect(diag.range).toBe(RANGE);
+  });
+
+  it("falls back to a generic message for unmatched errors", () => {
+    expect(buildToolStateErrorDiagnostic(new Error("boom"), RANGE).message).toBe(
+      "Tool state could not be validated: boom"
+    );
+  });
+
+  it("handles non-Error throws via String()", () => {
+    expect(buildToolStateErrorDiagnostic("raw string", RANGE).message).toContain("raw string");
   });
 });
 

--- a/server/packages/server-common/tests/unit/toolStateDiagnostics.test.ts
+++ b/server/packages/server-common/tests/unit/toolStateDiagnostics.test.ts
@@ -2,9 +2,7 @@ import { DiagnosticSeverity, type Range } from "vscode-languageserver-types";
 import type { ToolStateDiagnostic } from "../../src/languageTypes";
 import {
   buildCacheMissDiagnostic,
-  buildToolStateErrorDiagnostic,
   mapToolStateDiagnosticsToLSP,
-  paramNameFromContainerError,
 } from "../../src/providers/validation/toolStateDiagnostics";
 
 const RANGE = { start: { line: 0, character: 0 }, end: { line: 0, character: 10 } };
@@ -29,40 +27,6 @@ describe("buildCacheMissDiagnostic", () => {
     expect(diag.severity).toBe(DiagnosticSeverity.Warning);
     expect(diag.message).toContain("Could not resolve tool");
     expect(diag.message).toContain("my_tool");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// buildToolStateErrorDiagnostic / paramNameFromContainerError
-// ---------------------------------------------------------------------------
-
-describe("buildToolStateErrorDiagnostic", () => {
-  const WALKER_ERROR = new Error(
-    'Container parameter "advanced" (gx_section) has string value — expected dict/list. ' +
-      "This indicates legacy parameter encoding which is not supported. Decode the workflow first."
-  );
-
-  it("extracts the param name from a walker container error", () => {
-    expect(paramNameFromContainerError(WALKER_ERROR)).toBe("advanced");
-    expect(paramNameFromContainerError(new Error("boom"))).toBeUndefined();
-  });
-
-  it("renders a concise message for a walker container error", () => {
-    const diag = buildToolStateErrorDiagnostic(WALKER_ERROR, RANGE);
-    expect(diag.severity).toBe(DiagnosticSeverity.Error);
-    expect(diag.message).toBe("Invalid value for 'advanced': expected a nested object or list, not a plain value.");
-    expect(diag.message).not.toContain("Decode the workflow"); // native jargon stripped
-    expect(diag.range).toBe(RANGE);
-  });
-
-  it("falls back to a generic message for unmatched errors", () => {
-    expect(buildToolStateErrorDiagnostic(new Error("boom"), RANGE).message).toBe(
-      "Tool state could not be validated: boom"
-    );
-  });
-
-  it("handles non-Error throws via String()", () => {
-    expect(buildToolStateErrorDiagnostic("raw string", RANGE).message).toContain("raw string");
   });
 });
 

--- a/server/packages/workflow-tests-language-service/package.json
+++ b/server/packages/workflow-tests-language-service/package.json
@@ -5,7 +5,7 @@
   "author": "davelopez",
   "license": "MIT",
   "dependencies": {
-    "@galaxy-tool-util/schema": "^1.8.0",
+    "@galaxy-tool-util/schema": "^1.8.2",
     "@gxwf/server-common": "workspace:*",
     "@gxwf/yaml-language-service": "workspace:*",
     "inversify": "^6.0.2",

--- a/server/packages/workflow-tests-language-service/package.json
+++ b/server/packages/workflow-tests-language-service/package.json
@@ -5,7 +5,7 @@
   "author": "davelopez",
   "license": "MIT",
   "dependencies": {
-    "@galaxy-tool-util/schema": "^1.8.2",
+    "@galaxy-tool-util/schema": "^1.9.0",
     "@gxwf/server-common": "workspace:*",
     "@gxwf/yaml-language-service": "workspace:*",
     "inversify": "^6.0.2",

--- a/server/packages/workflow-tests-language-service/package.json
+++ b/server/packages/workflow-tests-language-service/package.json
@@ -5,7 +5,7 @@
   "author": "davelopez",
   "license": "MIT",
   "dependencies": {
-    "@galaxy-tool-util/schema": "^1.1.0",
+    "@galaxy-tool-util/schema": "^1.8.0",
     "@gxwf/server-common": "workspace:*",
     "@gxwf/yaml-language-service": "workspace:*",
     "inversify": "^6.0.2",

--- a/shared/src/requestsDefinitions.ts
+++ b/shared/src/requestsDefinitions.ts
@@ -144,6 +144,8 @@ export interface PopulateToolCacheResult {
 
 export interface GetToolCacheStatusResult {
   cacheSize: number;
+  /** Whether the server will auto-resolve uncached tools when a workflow opens. */
+  autoResolutionEnabled: boolean;
 }
 
 export interface GetWorkflowToolsParams {

--- a/test-data/yaml/validation/test_wf_iwc_missing.gxwf.yml
+++ b/test-data/yaml/validation/test_wf_iwc_missing.gxwf.yml
@@ -5,7 +5,7 @@ inputs:
 outputs: []
 steps:
   - tool_id: cat1
+    tool_version: "1.0.0"
     label: first_cat
-    state:
-      input1:
-        $link: input1
+    in:
+      input1: input1


### PR DESCRIPTION
Builds on #91 (list-form step resolution, native `tool_state` routing, gxformat2 connection completion). This PR = **#91 + a tool-util bump and the client-side fixes that make web-mode tool resolution actually work**. Until #91 merges its commits show here too; afterward this reduces to the two new commits.

## What's new on top of #91

### `chore(deps)`: bump `@galaxy-tool-util/*` 1.8.0 → 1.8.2
1.8.2 strips in-memory-only derived fields (`connected_paths`, `unique_tools`) at serialize time, so `clean`/`convert` output no longer leaks them as stray keys that downstream schema validators reject.

### `fix(web)`: enable tool auto-resolution + workspace-scoped ToolShed URL
Two related gaps that left web-mode tool resolution non-functional:

- **(A) Browser language clients now pass `toolAutoResolution`**, matching the node desktop clients (`client/src/extension.ts`). Without it the web server's `autoResolutionEnabled` stayed `false`, so opening a workflow never auto-fetched/cached its tools — no `tool_state` completion and a spurious "uncached tool_state" diagnostic. One-line parity fix.
- **(B) `galaxyWorkflows.toolShed.url` scope `machine` → `window`** so it can be set in workspace `.vscode/settings.json` (machine scope is user-settings-only). Lets a repo pin its ToolShed and unblocks web, where machine-scoped settings don't reach the language worker. `toolCache.directory` stays `machine` (a real filesystem path).

A and B are complementary: A arms the fetch-on-open trigger, B lets the URL reach the worker.

## Not included
- Single-client `PopulateToolCacheCommand` (native-only) — fix lives in `web_tool_cache_wiring`.
- ToolShed CORS for browser fetch is a ToolShed-server limitation (needs a CORS-enabled shed or proxy), not addressable here.

## Tests
- Server: 456 passing. Client: 58 passing. Lint clean.
- Manually verified in `vscode-test-web`: opening a `.gxwf.yml` now auto-resolves its tool, clears the diagnostic, and `tool_state` select/property-name completions work (captured for docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
